### PR TITLE
Extend and correct Typescript Types

### DIFF
--- a/types/index.esm.d.ts
+++ b/types/index.esm.d.ts
@@ -1,18 +1,36 @@
-import { ControllerDatasetOptions, PointHoverOptions, PointOptions, ScriptableAndArrayOptions, ScriptableContext, ChartType } from 'chart.js';
-import { AnyObject } from 'chart.js/types/basic';
+import {
+  Chart,
+  ChartComponent,
+  ChartType,
+  CoreChartOptions,
+  DatasetController,
+  Element,
+  ScriptableContext, Color, Scriptable
+} from 'chart.js';
+import {AnyObject} from 'chart.js/types/basic';
 
-export interface TreemapControllerDatasetOptions<TType extends ChartType>
-extends ControllerDatasetOptions,
-ScriptableAndArrayOptions<PointOptions, ScriptableContext<TType>>,
-ScriptableAndArrayOptions<PointHoverOptions, ScriptableContext<TType>> {
+export interface TreemapControllerDatasetOptions<TType extends ChartType> {
+  color?: Scriptable<Color, ScriptableContext<TType>>,
+  dividerCapStyle?: string,
+  dividerColor?: string,
+  dividerDash?: number[],
+  dividerDashOffset?: number,
+  dividerWidth?: number,
+  groupDividers?: boolean,
+  groupLabels?: boolean,
+  spacing?: number,
+  rtl?: boolean,
 
-  data?: unknown,
-  font: AnyObject,
-  groups: string[],
-  groupDividers: boolean,
-  rtl: boolean,
-  spacing: number,
-  tree: number[],
+  backgroundColor?: Scriptable<Color, ScriptableContext<TType>>;
+  borderColor?: Scriptable<Color, ScriptableContext<TType>>;
+  borderWidth?: number;
+
+  label?: Scriptable<string, ScriptableContext<TType>>;
+
+  data: any[], // Unknown makes tsc complain
+  groups?: string[],
+  tree: number[] | AnyObject[],
+  key?: string
 }
 
 export interface TreemapDataPoint {
@@ -20,7 +38,26 @@ export interface TreemapDataPoint {
   y: number,
   w: number,
   h: number,
-  v: number
+  /**
+   * Value
+   */
+  v: number,
+  /**
+   * Sum
+   */
+  s: number,
+  /**
+   * Depth, only available if grouping
+   */
+  l?: number,
+  /**
+   * Group name, only available if grouping
+   */
+  g?: string,
+  /**
+   * Group Sum, only available if grouping
+   */
+  gs?: number,
 }
 
 /*
@@ -41,5 +78,30 @@ declare module 'chart.js' {
 
   // interface TooltipOptions<TType extends ChartType> extends CoreInteractionOptions, TreemapInteractionOptions {
   // }
+}
+
+type TreemapOptions = {
+  backgroundColor: Color;
+  borderColor: Color;
+  borderWidth: number | { top?: number, right?: number, bottom?: number, left?: number }
+}
+
+type TreemapConfig = {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export type TreemapController = DatasetController;
+export const TreemapController: ChartComponent & {
+  prototype: TreemapController;
+  new(chart: Chart, datasetIndex: number): TreemapController
+};
+
+export type TreemapElement = Element<TreemapConfig, TreemapOptions>;
+export const TreemapElement: ChartComponent & {
+  prototype: TreemapElement;
+  new(cfg: TreemapConfig): TreemapElement
 }
 

--- a/types/index.esm.d.ts
+++ b/types/index.esm.d.ts
@@ -1,16 +1,14 @@
 import {
   Chart,
   ChartComponent,
-  ChartType,
   CoreChartOptions,
   DatasetController,
   Element,
   ScriptableContext, Color, Scriptable
 } from 'chart.js';
-import {AnyObject} from 'chart.js/types/basic';
 
-export interface TreemapControllerDatasetOptions<TType extends ChartType> {
-  color?: Scriptable<Color, ScriptableContext<TType>>,
+export interface TreemapControllerDatasetOptions<DType> {
+  color?: Scriptable<Color, ScriptableContext<'treemap'>>,
   dividerCapStyle?: string,
   dividerColor?: string,
   dividerDash?: number[],
@@ -21,16 +19,17 @@ export interface TreemapControllerDatasetOptions<TType extends ChartType> {
   spacing?: number,
   rtl?: boolean,
 
-  backgroundColor?: Scriptable<Color, ScriptableContext<TType>>;
-  borderColor?: Scriptable<Color, ScriptableContext<TType>>;
+  backgroundColor?: Scriptable<Color, ScriptableContext<'treemap'>>;
+  borderColor?: Scriptable<Color, ScriptableContext<'treemap'>>;
   borderWidth?: number;
 
-  label?: Scriptable<string, ScriptableContext<TType>>;
+  label?: Scriptable<string, ScriptableContext<'treemap'>>;
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   data: any[], // Unknown makes tsc complain
-  groups?: string[],
-  tree: number[] | AnyObject[],
-  key?: string
+  groups?: Array<keyof DType>;
+  tree: number[] | DType[];
+  key?: keyof DType;
 }
 
 export interface TreemapDataPoint {
@@ -69,8 +68,11 @@ declare module 'chart.js' {
   export interface ChartTypeRegistry {
     treemap: {
       chartOptions: CoreChartOptions<'treemap'>;
-      datasetOptions: TreemapControllerDatasetOptions<'treemap'>;
+      // Must be any, since we don't know what type will be used eventually
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      datasetOptions: TreemapControllerDatasetOptions<any>;
       defaultDataPoint: TreemapDataPoint;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       parsedDataType: any,
       scales: never;
     }
@@ -103,5 +105,4 @@ export type TreemapElement = Element<TreemapConfig, TreemapOptions>;
 export const TreemapElement: ChartComponent & {
   prototype: TreemapElement;
   new(cfg: TreemapConfig): TreemapElement
-}
-
+};


### PR DESCRIPTION
- Add types for TreemapController and TreemapElement
- Fix types for TreemapControllerDatasetOptions
  - Did not match code or samples
- Extend types for TreemapDataPoint
  - missing grouping keys

Resolves #33