### PR TITLE
Type compatibility with Chart.js v3.5.0

### DIFF
--- a/types/index.esm.d.ts
+++ b/types/index.esm.d.ts
@@ -76,6 +76,7 @@ declare module 'chart.js' {
       chartOptions: CoreChartOptions<'treemap'>;
       datasetOptions: TreemapControllerDatasetOptions<Record<string, unknown>>;
       defaultDataPoint: TreemapDataPoint;
+      metaExtensions: {};
       parsedDataType: unknown,
       scales: never;
     }


### PR DESCRIPTION
Fixes: https://github.com/kurkle/chartjs-chart-treemap/issues/49

Signed-off-by: Volker Theile <votdev@gmx.de>
