### PR TITLE
Add VisualElement extension to Treemap element type definition

### DIFF
--- a/types/index.esm.d.ts
+++ b/types/index.esm.d.ts
@@ -2,9 +2,10 @@ import {
   Chart,
   ChartComponent,
   DatasetController,
-  Element,
+  Element, VisualElement,
   ScriptableContext, Color, Scriptable, FontSpec
 } from 'chart.js';
+import { AnyObject } from 'chart.js/types/basic';
 
 type TreemapScriptableContext = ScriptableContext<'treemap'> & {
   raw: TreemapDataPoint
@@ -107,7 +108,7 @@ declare module 'chart.js' {
       chartOptions: CoreChartOptions<'treemap'>;
       datasetOptions: TreemapControllerDatasetOptions<Record<string, unknown>>;
       defaultDataPoint: TreemapDataPoint;
-      metaExtensions: {};
+      metaExtensions: AnyObject;
       parsedDataType: unknown,
       scales: never;
     }
@@ -117,13 +118,13 @@ declare module 'chart.js' {
   // }
 }
 
-type TreemapOptions = {
+export interface TreemapOptions {
   backgroundColor: Color;
   borderColor: Color;
   borderWidth: number | { top?: number, right?: number, bottom?: number, left?: number }
 }
 
-type TreemapConfig = {
+export interface TreemapConfig {
   x: number;
   y: number;
   width: number;
@@ -136,7 +137,11 @@ export const TreemapController: ChartComponent & {
   new(chart: Chart, datasetIndex: number): TreemapController
 };
 
-export type TreemapElement = Element<TreemapConfig, TreemapOptions>;
+export interface TreemapElement<
+  T extends TreemapConfig = TreemapConfig,
+  O extends TreemapOptions = TreemapOptions
+> extends Element<T, O>, VisualElement {}
+
 export const TreemapElement: ChartComponent & {
   prototype: TreemapElement;
   new(cfg: TreemapConfig): TreemapElement


### PR DESCRIPTION
This PR is added VisualElement interface as extension of Treemap element which is implementing all methods of that interface.