### PR TITLE
Use isObject from CHART.JS helpers instead of an internal one

### DIFF
--- a/src/element.js
+++ b/src/element.js
@@ -1,5 +1,5 @@
 import {Element} from 'chart.js';
-import {isObject} from './utils';
+import {isObject} from 'chart.js/helpers';
 
 /**
  * Helper function to get the bounds of the rect

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,3 +1,5 @@
+import {isObject} from 'chart.js/helpers';
+
 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/flat
 export function flatten(input) {
   const stack = [...input];
@@ -53,11 +55,6 @@ export function group(values, grp, key, mainGrp, mainValue) {
   });
 
   return ret;
-}
-
-export function isObject(obj) {
-  const type = typeof obj;
-  return type === 'function' || type === 'object' && !!obj;
 }
 
 export function index(values, key) {

--- a/test/specs/utils.spec.js
+++ b/test/specs/utils.spec.js
@@ -1,4 +1,4 @@
-import {flatten, group, sort, sum, isObject} from '../../src/utils';
+import {flatten, group, sort, sum} from '../../src/utils';
 
 describe('utils', function() {
 
@@ -59,12 +59,6 @@ describe('utils', function() {
       var a = [{x: 8, y: 1}, {x: 3, y: 2}, {x: 5, y: 3}];
       expect(sum(a, 'x')).toEqual(16);
       expect(sum(a, 'y')).toEqual(6);
-    });
-  });
-
-  describe('isObject', function() {
-    it('should detect objects', function() {
-      expect(isObject({})).toBeTrue();
     });
   });
 });


### PR DESCRIPTION
This PR is replacing `isObject` function from `utils` in order to use `isObject` function from `Chart.helpers`