### PR TITLE
Remove chartjs date-fns adapter from test suite because not used

### DIFF
--- a/karma.conf.cjs
+++ b/karma.conf.cjs
@@ -61,7 +61,6 @@ module.exports = async function(karma) {
       {pattern: './test/fixtures/**/*.js', included: false},
       {pattern: './test/fixtures/**/*.png', included: false},
       'node_modules/chart.js/dist/chart.umd.js',
-      'node_modules/chartjs-adapter-date-fns/dist/chartjs-adapter-date-fns.bundle.js',
       {pattern: 'test/index.js', watched: false},
       {pattern: 'src/index.js', watched: false},
       {pattern: 'test/specs/**/*.js', watched: false}


### PR DESCRIPTION
Test suite was related to `date-fns` adapter but not used.