### PR TITLE
chore: group dependabot updates and standardize README badges

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,13 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      dev-dependencies:
+        dependency-type: "development"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      actions:
+        patterns: ["*"]

--- a/README.md
+++ b/README.md
@@ -5,9 +5,10 @@
 [![npm](https://img.shields.io/npm/v/chartjs-chart-treemap.svg)](https://www.npmjs.com/package/chartjs-chart-treemap)
 [![release](https://img.shields.io/github/release/kurkle/chartjs-chart-treemap.svg?style=flat-square)](https://github.com/kurkle/chartjs-chart-treemap/releases/latest)
 ![npm bundle size](https://img.shields.io/bundlephobia/min/chartjs-chart-treemap.svg)
-![GitHub](https://img.shields.io/github/license/kurkle/chartjs-chart-treemap.svg)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=kurkle_chartjs-chart-treemap&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=kurkle_chartjs-chart-treemap)
+[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=kurkle_chartjs-chart-treemap&metric=coverage)](https://sonarcloud.io/summary/new_code?id=kurkle_chartjs-chart-treemap)
 [![documentation](https://img.shields.io/static/v1?message=Documentation&color=informational)](https://chartjs-chart-treemap.pages.dev)
+![GitHub](https://img.shields.io/github/license/kurkle/chartjs-chart-treemap.svg)
 
 ![TreeMap Example Image](treemap.png)
 


### PR DESCRIPTION
## Summary
- `.github/dependabot.yml`: group npm dev-dependency bumps into one PR (`dev-dependencies`, `dependency-type: development`) and all github-actions bumps into one PR (`actions`, `patterns: ["*"]`), matching the shared dependabot config format being rolled out across kurkle repos. Prod npm dependencies are intentionally left ungrouped.
- `README.md`: added the missing Sonar coverage badge and reordered the badge row to the standard sequence — npm version, github release, bundlephobia min size, Sonar quality gate, Sonar coverage, documentation, github license — matching chartjs-chart-matrix's README.

## Not included
- No `engines` field added to `package.json` — this is a published browser library, so an `engines` constraint would needlessly restrict installers. That standardization only applies to `@kurkle/configs` and `astro-chartjs-editor`.

## Verification
- `npm run lint` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)