### PR TITLE
chore: ignore TypeScript major bumps in dependabot dev-dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,12 @@ updates:
     groups:
       dev-dependencies:
         dependency-type: "development"
+    ignore:
+      # @astrojs/check requires typescript ^5 || ^6, so TS 7 breaks npm ci
+      # with ERESOLVE and stalls the whole dev-dependencies group.
+      # Remove this once @astrojs/check supports TypeScript 7.
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
## Summary
- Add an `ignore` rule to the npm `dependabot.yml` block for `typescript` major/semver-major updates.

## Why
`@astrojs/check@0.9.10` (its latest release) declares a `typescript` peer range of `^5.0.0 || ^6.0.0`. A TypeScript 7 bump makes `npm clean-install` fail with ERESOLVE, which stalls the whole grouped `dev-dependencies` PR (#440) — not just a TypeScript-specific type error. Since there's no newer `@astrojs/check` release that supports TS 7, this can't be fixed by bumping that package too.

Forcing TS 7 via npm `overrides` was considered and rejected: `@astrojs/check` uses the TypeScript compiler API directly, so overriding the resolved version would likely break `astro check` for real rather than just silencing the ERESOLVE.

Minor and patch TypeScript updates are unaffected and still flow through the `dev-dependencies` group normally.

## Verification
- `npm run lint` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)