### PR TITLE
ci: scope secrets explicitly and scan workflow files with Sonar

### DIFF
--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -13,7 +13,8 @@ jobs:
     uses: kurkle/configs/.github/workflows/shared-ci.yml@v1
     with:
       run-audit-signatures: true
-    secrets: inherit
+    secrets:
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
   release:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -12,7 +12,8 @@ jobs:
     uses: kurkle/configs/.github/workflows/shared-ci.yml@v1
     with:
       fetch-depth: 1
-    secrets: inherit
+    secrets:
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
   compressed-size:
     runs-on: ubuntu-latest

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -5,8 +5,15 @@ sonar.organization=kurkle
 sonar.projectName=chartjs-chart-treemap
 
 # Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
-sonar.sources=src/
+sonar.sources=src/,.github/workflows
 sonar.exclusions=**/*.test.*
 sonar.tests=test/
 
 sonar.javascript.lcov.reportPaths=coverage/chrome/lcov.info,coverage/firefox/lcov.info,coverage/unit/lcov.info
+
+# The floating v1 tag is deliberate: it is how a fix in kurkle/configs reaches
+# every repository without a pull request in each one. Pinning a commit SHA
+# would defeat that mechanism.
+sonar.issue.ignore.multicriteria=e1
+sonar.issue.ignore.multicriteria.e1.ruleKey=githubactions:S7637
+sonar.issue.ignore.multicriteria.e1.resourceKey=.github/workflows/*.yml


### PR DESCRIPTION
## Summary
- Replace `secrets: inherit` with an explicit `SONAR_TOKEN` passthrough in `pr-ci.yml` and `main-ci.yml`, now that the shared workflow (`kurkle/configs@v1.3.0`, pinned to the floating `@v1` tag) declares that secret by name instead of requiring the whole secret set. `GITHUB_TOKEN` needs no passthrough — it's always available to the job.
- Add `.github/workflows` to `sonar.sources` in `sonar-project.properties` so Sonar actually analyzes the workflow files.
- Add a Sonar ignore rule for `githubactions:S7637` scoped to `.github/workflows/*.yml`, with a comment explaining that the floating `@v1` tag on the reusable workflow is intentional (it's how a fix in `kurkle/configs` reaches every repo without a PR in each one).

## Verification
- `npm run lint` passes; confirmed no remaining `secrets: inherit` anywhere in `.github/workflows`.
- Checking this PR's own Sonar run to confirm workflow files are actually indexed/analyzed and that neither S7635 nor S7637 fire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)