### PR TITLE
ci: skip npm lifecycle scripts during install

### DIFF
--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -37,7 +37,7 @@ jobs:
           cache: npm
 
       - name: Install dependencies
-        run: npm clean-install
+        run: npm clean-install --ignore-scripts
 
       - name: Build
         run: npm run build

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -29,7 +29,7 @@ jobs:
           cache: npm
 
       - name: Install dependencies
-        run: npm clean-install
+        run: npm clean-install --ignore-scripts
 
       - name: Build
         run: npm run build
@@ -40,3 +40,4 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           pattern: "./dist/*.{js,cjs}"
           build-script: npm run build
+          install-script: npm ci --ignore-scripts


### PR DESCRIPTION
## Summary
- `main-ci.yml` release job: `npm clean-install` → `npm clean-install --ignore-scripts`
- `pr-ci.yml` compressed-size job: `npm clean-install` → `npm clean-install --ignore-scripts`
- `preactjs/compressed-size-action`: added `install-script: npm ci --ignore-scripts`, since the action installs both the PR branch and base branch itself internally to diff them.

## Why
Dependency lifecycle scripts (preinstall/install/postinstall) are a common malware distribution vector in the npm ecosystem. Only two packages in this dependency tree run install scripts for anything real — `esbuild` and `@swc/core` — and both resolve their native binaries from optional platform packages rather than relying on a postinstall step, so `--ignore-scripts` doesn't break them.

The shared CI workflow (`kurkle/configs`) gets this hardening independently and isn't touched here.

## Verification
- This PR's own CI is the real test: build and the full test suite (unit, karma fixtures, browser/node integration) run against dependencies installed with `--ignore-scripts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)