### PR TITLE
docs: restore usage sample chart broken by legacy docs cleanup

### DIFF
--- a/docs/samples/usage.md
+++ b/docs/samples/usage.md
@@ -1,0 +1,51 @@
+# Usage
+
+```js chart-editor
+// <block:utils:1>
+function colorFromRaw(ctx) {
+  if (ctx.type !== 'data') {
+    return 'transparent';
+  }
+  const value = ctx.raw.v;
+  let alpha = (1 + Math.log(value)) / 5;
+  const color = 'green';
+  return helpers.color(color)
+    .alpha(alpha)
+    .rgbString();
+}
+// </block:utils>
+
+// <block:config:0>
+const config = {
+  type: 'treemap',
+  data: {
+    datasets: [
+      {
+        label: 'My treemap dataset',
+        tree: [15, 6, 6, 5, 4, 3, 2, 2],
+        borderColor: 'green',
+        borderWidth: 1,
+        spacing: 0,
+        backgroundColor: (ctx) => colorFromRaw(ctx),
+      }
+    ],
+  },
+  options: {
+    plugins: {
+      title: {
+        display: true,
+        text: 'My treemap chart'
+      },
+      legend: {
+        display: false
+      }
+    }
+  }
+};
+
+// </block:config>
+
+module.exports = {
+  config,
+};
+```

--- a/docs/src/components/SampleChart.astro
+++ b/docs/src/components/SampleChart.astro
@@ -80,10 +80,7 @@ interface Props {
     },
   })
 
-  const modules = {
-    ...import.meta.glob('../../samples/*.md', { query: '?raw', import: 'default', eager: true }),
-    ...import.meta.glob('../../*.md', { query: '?raw', import: 'default', eager: true }),
-  }
+  const modules = import.meta.glob('../../samples/*.md', { query: '?raw', import: 'default', eager: true })
 
   function parseSample(raw) {
     const fence = raw.match(/```js chart-editor\n([\s\S]*?)\n```/)
@@ -94,7 +91,7 @@ interface Props {
   }
 
   function loadSample(source) {
-    const key = source === 'usage' ? '../../usage.md' : `../../samples/${source}.md`
+    const key = `../../samples/${source}.md`
     const raw = modules[key]
     if (!raw) {
       throw new Error(`Unknown sample: ${source}`)

--- a/src/content/docs/usage.mdx
+++ b/src/content/docs/usage.mdx
@@ -10,56 +10,6 @@ The treemap chart provides a method for displaying hierarchical data using neste
 
 Treemaps display hierarchical (tree-structured) data as a set of nested rectangles. Each branch of the tree is given a rectangle, which is then tiled with smaller rectangles representing sub-branches. A leaf node's rectangle has an area proportional to a specified dimension of the data.
 
-```js chart-editor
-// <block:utils:1>
-function colorFromRaw(ctx) {
-  if (ctx.type !== 'data') {
-    return 'transparent';
-  }
-  const value = ctx.raw.v;
-  let alpha = (1 + Math.log(value)) / 5;
-  const color = 'green';
-  return helpers.color(color)
-    .alpha(alpha)
-    .rgbString();
-}
-// </block:utils>
-
-// <block:config:0>
-const config = {
-  type: 'treemap',
-  data: {
-    datasets: [
-      {
-        label: 'My treemap dataset',
-        tree: [15, 6, 6, 5, 4, 3, 2, 2],
-        borderColor: 'green',
-        borderWidth: 1,
-        spacing: 0,
-        backgroundColor: (ctx) => colorFromRaw(ctx),
-      }
-    ],
-  },
-  options: {
-    plugins: {
-      title: {
-        display: true,
-        text: 'My treemap chart'
-      },
-      legend: {
-        display: false
-      }
-    }
-  }
-};
-
-// </block:config>
-
-module.exports = {
-  config,
-};
-```
-
 ## Dataset Options
 
 Namespaces:


### PR DESCRIPTION
## Problem

The chart on the `/usage/` page is broken in production. `src/content/docs/usage.mdx` renders `<SampleChart title="Usage" source="usage" />`, and `docs/src/components/SampleChart.astro` mapped that one sample as a special case to `../../usage.md`. That file (`docs/usage.md`) was deleted in 71c19e39 ("chore: remove pre-Astro-migration legacy docs files") as part of an otherwise correct cleanup — it was rightly identified as an unused legacy file from the Astro build's point of view, but `SampleChart.astro`'s live dependency on it went unnoticed.

`import.meta.glob` does not fail on a missing key, so `npm run docs` stays green. Only in the browser does `mount()` throw `Error("Unknown sample: usage")`, and no chart is drawn.

The root cause was confirmed independently before fixing: `docs/samples/` contained exactly 12 files (no `usage.md`), and the module map in the published production bundle had no `"../../usage.md"` key.

## Fix

The sample code was not lost — it was still in `usage.mdx` as an inline code fence. This makes the usage sample consistent with the other 12:

1. Added `docs/samples/usage.md` in the same format as the others (`# Usage` followed by a ```js chart-editor fence), with the content lifted verbatim from `usage.mdx`.
2. Removed that fence from `usage.mdx` — the prose, tables and other examples are untouched. This is deliberate consistency: no other sample page shows its code inline to the reader, so the usage page no longer does either.
3. Simplified `SampleChart.astro`: dropped the second glob (`'../../*.md'`) and the `source === 'usage'` ternary. What remains is one line: `` const key = `../../samples/${source}.md` ``.

## Evidence

The docs were built and the resulting bundle read the same way the production bundle was read while diagnosing the problem:

```
$ npm run docs
...
16 page(s) built in 2.28s

$ grep -o '"\.\./\.\./samples/[a-zA-Z]*\.md"' dist/docs/_astro/SampleChart*.js | sort -u
"../../samples/basic.md"
"../../samples/captions.md"
"../../samples/datalabels.md"
"../../samples/displayMode.md"
"../../samples/dividers.md"
"../../samples/groups.md"
"../../samples/labels.md"
"../../samples/labelsFontsAndColors.md"
"../../samples/missingGroups.md"
"../../samples/rtl.md"
"../../samples/tree.md"
"../../samples/usage.md"
"../../samples/zoom.md"
```

13 keys, `usage.md` among them (12 before the fix, with no `usage` key). Also verified that the old `"../../usage.md"` key no longer appears in the bundle (0 matches), and that `/usage/index.html` still renders the `data-sample-source="usage"` container that the module map now covers.

`npm test` passed in full (65 jasmine unit specs, 142 karma fixture tests on Chrome and Firefox, browser-esm/node-cjs/node-esm integration tests, tsc typecheck).

## Scope

This is deliberately an interim fix. A separate later change migrates chartjs-chart-matrix and chartjs-chart-treemap to `@kurkle/astro-chartjs-editor` and removes `SampleChart.astro` entirely — that is not started here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
