### PR TITLE
docs: rewrite README as a thin portal to the docs site

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,51 @@
 [![documentation](https://img.shields.io/static/v1?message=Documentation&color=informational)](https://chartjs-chart-treemap.pages.dev)
 ![GitHub](https://img.shields.io/github/license/kurkle/chartjs-chart-treemap.svg)
 
+chartjs-chart-treemap adds a `treemap` chart type to Chart.js that displays hierarchical (tree-structured) data as a set of nested rectangles, where each rectangle's area is proportional to the value it represents. It's for visualizing part-to-whole or hierarchical data — disk usage, sales by category, org structures — in less space than a bar or pie chart would need.
+
+## Example
+
 ![TreeMap Example Image](treemap.png)
+
+## Installation
+
+```bash
+npm install chartjs-chart-treemap
+```
+
+Or via CDN:
+
+```html
+<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/chartjs-chart-treemap"></script>
+```
+
+## Quickstart
+
+```js
+import { Chart, registerables } from 'chart.js';
+import { TreemapController, TreemapElement } from 'chartjs-chart-treemap';
+
+Chart.register(...registerables, TreemapController, TreemapElement);
+
+new Chart(document.getElementById('chart'), {
+  type: 'treemap',
+  data: {
+    datasets: [
+      {
+        tree: [6, 6, 4, 3, 2, 2, 1],
+        backgroundColor: 'rgba(54, 162, 235, 0.6)',
+      },
+    ],
+  },
+});
+```
+
+See more integration options (script tag, other module loaders) in the [documentation](https://chartjs-chart-treemap.pages.dev/integration).
 
 ## Documentation
 
-You can find documentation for chartjs-chart-treemap at [https://chartjs-chart-treemap.pages.dev/](https://chartjs-chart-treemap.pages.dev/).
+Full documentation, including the dataset and options reference, is at [https://chartjs-chart-treemap.pages.dev/](https://chartjs-chart-treemap.pages.dev/).
 
 ## Development
 


### PR DESCRIPTION
## Summary

- Rewrite `README.md` so it actually shows how to use the package: adds `## Installation` (npm + CDN) and `## Quickstart` (minimal working example), which were entirely missing before.
- Keeps the badge row, `## Documentation`, `## Development`, and `## License` sections as-is (already correct for this repo — see notes below).
- No config/options reference is added to the README; it stays a thin pointer to https://chartjs-chart-treemap.pages.dev/, in line with the fleet-wide documentation unification (README as a thin portal, docs site as the single source for the config reference).

## Verification

- Quickstart code (`Chart.register(...registerables, TreemapController, TreemapElement)` + `tree` dataset) was executed against the locally built `dist` using `@napi-rs/canvas` in Node before being added to the README — it is not written from memory. An initial attempt that only registered `TreemapController`/`TreemapElement` (no `registerables`) failed with `Error: "linear" is not a registered scale.`, which is why the Quickstart registers `registerables` too.
- The import/register shape matches the already-published `src/content/docs/integration.mdx` "Bundlers" example (verified this is what the pre-commit hook's `astro build` step actually renders at `/integration/index.html`).
- The `tree` values `[6, 6, 4, 3, 2, 2, 1]` and the CDN registration pattern also match `test/integration/node-module/test.mjs`, which is executed by `npm test` on every run (`test:integration:node-module`).
- All links checked with `curl -o /dev/null -w "%{http_code}"`: GitHub releases page (200), SonarCloud summary (200), docs home `/` (200), `/usage` (200), `/integration` (200), MIT license (200), chartjs.org (200), jsdelivr CDN URLs for `chart.js` and `chartjs-chart-treemap` (200 each). The npm package page returns 403 to `curl` (npmjs's bot-blocking, not a broken link — unchanged from the prior README and works in a real browser).
- Coverage badge: confirmed via SonarCloud API (`/api/measures/component?...&metricKeys=coverage`) that this project has real coverage data (97.0%) — the badge was already present in the previous README and is left as-is, not newly added.
- `npm test` run in full both before and after the change: 142 unit/fixture specs (Chrome + Firefox), 3 browser-module integration specs, and both Node integration tests (`test:integration:node-commonjs`, `test:integration:node-module`) — all green. The pre-commit hook also ran lint, typecheck, build, and a full `astro build` of the docs site, which succeeded and generated `/integration/index.html`, `/usage/index.html`, etc., confirming those routes are real.

## Out of scope / notes for the maintainer

- PR #446 (`fix/usage-sample-chart`) is untouched — this PR only edits `README.md`.
- The existing README already had a `Coverage` badge (the task brief I was given assumed it might be missing); I left it in place unchanged since SonarCloud confirms real data behind it.
- I did not reuse `docs/samples/basic.md` / `usage.md` verbatim for the Quickstart because they depend on chart-editor-sandbox-only globals (`Utils`, `helpers`) that don't exist in a plain bundler/Node environment — using them as-is in the README would produce a `ReferenceError` for anyone copy-pasting it outside the docs site's live editor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)