### PR TITLE
docs: remove deprecated z import from content.config.ts

### DIFF
--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -4,13 +4,11 @@
 import { docsLoader } from '@astrojs/starlight/loaders'
 import { docsSchema } from '@astrojs/starlight/schema'
 
-import { defineCollection, z } from 'astro:content'
+import { defineCollection } from 'astro:content'
 
 const docs = defineCollection({
   loader: docsLoader(),
-  schema: docsSchema({
-    extend: z.object({}),
-  }),
+  schema: docsSchema(),
 })
 
 export const collections = { docs }


### PR DESCRIPTION
## Summary

`src/content.config.ts` imported the deprecated `z` export from `astro:content`. Confirmed independently in astro's own shipped type declarations (`node_modules/astro/types/content.d.ts`):

```ts
// TODO: remove in Astro 8
/**
 * @deprecated
 * `import { z } from 'astro:content'` is deprecated and will be removed
 * in Astro 8. Use `import { z } from 'astro/zod'` instead.
 */
export const z = zod.z;
```

Its only use in this file was `docsSchema({ extend: z.object({}) })` — extending Starlight's default docs schema with an empty object schema. Checked `docsSchema`'s own types (`node_modules/@astrojs/starlight/dist/schema.d.ts`): `extend` is optional, and when omitted the return type collapses to Starlight's unmodified `DefaultSchema` (`[T] extends [never] ? DefaultSchema : DeepMergedSchema<DefaultSchema, T>`). Merging in an empty-shape schema is therefore a no-op — this wasn't just a deprecated import, it was dead code riding along with it.

So instead of swapping the import to `astro/zod` (modernizing dead code), this PR removes `z` and the no-op `extend` option entirely:

```ts
import { docsLoader } from '@astrojs/starlight/loaders'
import { docsSchema } from '@astrojs/starlight/schema'

import { defineCollection } from 'astro:content'

const docs = defineCollection({
  loader: docsLoader(),
  schema: docsSchema(),
})

export const collections = { docs }
```

`defineCollection` is untouched — only `z` was deprecated, not the rest of the `astro:content` module. Both `/// <reference ...>` lines at the top of the file are unchanged. One deviation from the exact snippet I was handed: I kept a blank line between the `@astrojs/*` import group and the `astro:content` import (matching this file's own pre-existing convention) because Biome's `organizeImports` assist flags a missing blank line between those groups as an error — the snippet without it doesn't pass this repo's `npm run lint`.

## Verification

- **`astro check`**: 0 errors/warnings/hints, both before and after this change. This is not meaningful evidence on its own, and I want to be upfront about that rather than imply otherwise: I confirmed by injecting a deliberate blatant type error into `content.config.ts` (`const x: number = 'not a number'`) that `astro check` reports 0 errors even then — it only type-checks `.astro` template files ("Getting diagnostics for Astro files", 13 files both before and after), not plain `.ts` source files like this one. So `astro check` was never going to surface this deprecation, or any other issue in this file, regardless of the fix. Plain `tsc --noEmit` (the `typecheck` script, which does include this file per `tsconfig.json`'s `include: ["./src/**/*"]`) also doesn't surface it — TypeScript's CLI doesn't turn `@deprecated` JSDoc into a compiler diagnostic; that's an editor/language-server-only hint. The deprecation is real (verified directly in astro's shipped `.d.ts` above) but no tool in this repo's pipeline was actually emitting a warning for it, before or after.
- `npm run docs`: 16 pages built, matching the page count before this change exactly (`Found 16 HTML files`, `16 page(s) built`).
- `npm run lint` (`biome check`): clean.
- `npm test`: 142 unit/fixture specs (Chrome + Firefox), 3 browser-module integration specs, both Node integration tests — all green.
- `npm ci` then a lockfile diff check: empty (no dependency changes in this PR).
- Branch currency: branched from `origin/main`, `git rev-list --count HEAD..origin/main` → 0.

## Other deprecations noticed (reporting only, not fixed here)

- Grepped the repo for any other `from 'astro:content'` imports — this is the only one, so no similar fix needed elsewhere in this repo.
- `npm ci` prints pre-existing deprecation warnings for transitive dependencies (`inflight@1.0.6`, `rimraf@3.0.2`, two `glob@7.2.3` warnings, `sourcemap-codec@1.4.8`). These aren't new, aren't related to this change, and are out of scope here — flagging per your standing request to report rather than fix.

## Scope

Only `src/content.config.ts`. Per instruction, the same fix should go to `chartjs-chart-matrix` and `chartjs-chart-sankey` separately — not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
