### PR TITLE
docs: point Ecosystem sidebar links to their own docs sites

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -78,11 +78,11 @@ export default defineConfig({
             },
             {
               label: 'chartjs-plugin-autocolors',
-              link: 'https://github.com/kurkle/chartjs-plugin-autocolors',
+              link: 'https://chartjs-plugin-autocolors.pages.dev/',
             },
             {
               label: 'chartjs-plugin-gradient',
-              link: 'https://github.com/kurkle/chartjs-plugin-gradient',
+              link: 'https://chartjs-plugin-gradient.pages.dev/',
             },
           ],
           label: 'Ecosystem',


### PR DESCRIPTION
## Summary

`astro.config.mjs`'s `Ecosystem` sidebar block linked `chartjs-plugin-autocolors` and `chartjs-plugin-gradient` to their GitHub repos, even though both now have their own documentation sites. Updated both:

| Label | Before | After |
| --- | --- | --- |
| `chartjs-plugin-autocolors` | `https://github.com/kurkle/chartjs-plugin-autocolors` | `https://chartjs-plugin-autocolors.pages.dev/` |
| `chartjs-plugin-gradient` | `https://github.com/kurkle/chartjs-plugin-gradient` | `https://chartjs-plugin-gradient.pages.dev/` |

`Awesome Chart.js` is untouched — it's a GitHub repo (a curated list), not a docs site, so `https://github.com/chartjs/awesome` stays correct.

## A discrepancy worth flagging

I was told matrix's and sankey's `Ecosystem` blocks are "already correct." Checked both directly via the GitHub API (not a local clone, to avoid stale-clone false positives):

```
gh api repos/kurkle/chartjs-chart-matrix/contents/astro.config.mjs -H "Accept: application/vnd.github.raw"
gh api repos/kurkle/chartjs-chart-sankey/contents/astro.config.mjs -H "Accept: application/vnd.github.raw"
```

As of this PR, **both repos' `main` branches still link `chartjs-plugin-autocolors` and `chartjs-plugin-gradient` to their GitHub repos**, not to `pages.dev`. So the "already correct" premise doesn't hold for either repo right now — possibly there are open, unmerged PRs for them that just haven't landed yet, but on `main` today they're not fixed. Not touching either repo (out of scope here either way), just flagging since it contradicts what I was told.

## Verification

- `curl -s -o /dev/null -w "%{http_code}" -L https://chartjs-plugin-autocolors.pages.dev/` → `200`
- `curl -s -o /dev/null -w "%{http_code}" -L https://chartjs-plugin-gradient.pages.dev/` → `200`
- `npm run docs`: 16 pages built, same as before this change (`Found 16 HTML files`, `16 page(s) built`).
- Inspected the built HTML directly (`dist/docs/usage/index.html`) rather than trusting the source config:
  ```
  <a href="https://chartjs-plugin-autocolors.pages.dev/" class="astro-rmhv4bp6"><span class="astro-rmhv4bp6">chartjs-plugin-autocolors</span></a>
  <a href="https://chartjs-plugin-gradient.pages.dev/" class="astro-rmhv4bp6"><span class="astro-rmhv4bp6">chartjs-plugin-gradient</span></a>
  ```
  and confirmed `Awesome Chart.js` is still `href="https://github.com/chartjs/awesome"`.
- `npm run lint` (`biome check`): clean.
- `npm test`: 142 unit/fixture specs (Chrome + Firefox), 3 browser-module integration specs, both Node integration tests — all green.
- `npm ci` then a lockfile diff check: empty (no dependency changes).
- Branch currency: branched from `origin/main`, `git rev-list --count HEAD..origin/main` → 0.

## Scope

Only the two links in `astro.config.mjs`'s `Ecosystem` block. No other stale links reviewed or touched — reporting only, per instruction, if anything else looked out of date, but nothing else in this block needed a change beyond these two.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
