### PR TITLE
ci: move Cloudflare Pages docs deploy into a shared workflow

### DIFF
--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -24,6 +24,9 @@ jobs:
       id-token: write
       issues: write
       pull-requests: write
+    outputs:
+      released: ${{ steps.release-version.outputs.released }}
+      version: ${{ steps.release-version.outputs.version }}
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -60,36 +63,14 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Resolved released version: $VERSION"
 
-      - name: Update Cloudflare Pages production docs version
-        if: steps.release-version.outputs.released == 'true'
-        env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          CLOUDFLARE_PAGES_PROJECT: ${{ secrets.CLOUDFLARE_PAGES_PROJECT }}
-          DOCS_VERSION: ${{ steps.release-version.outputs.version }}
-        run: |
-          curl --fail --silent --show-error \
-            --request PATCH \
-            --url "https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/pages/projects/${CLOUDFLARE_PAGES_PROJECT}" \
-            --header "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
-            --header 'Content-Type: application/json' \
-            --data @- <<EOF
-          {
-            "deployment_configs": {
-              "production": {
-                "env_vars": {
-                  "DOCS_VERSION": {
-                    "type": "plain_text",
-                    "value": "${DOCS_VERSION}"
-                  }
-                }
-              }
-            }
-          }
-          EOF
-
-      - name: Trigger Cloudflare Pages production deploy
-        if: steps.release-version.outputs.released == 'true'
-        env:
-          CLOUDFLARE_PAGES_DEPLOY_HOOK: ${{ secrets.CLOUDFLARE_PAGES_DEPLOY_HOOK }}
-        run: curl --fail --silent --show-error --request POST "$CLOUDFLARE_PAGES_DEPLOY_HOOK"
+  docs-deploy:
+    needs: release
+    if: needs.release.outputs.released == 'true'
+    uses: kurkle/configs/.github/workflows/docs-deploy.yml@v1
+    with:
+      version: ${{ needs.release.outputs.version }}
+    secrets:
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      CLOUDFLARE_PAGES_PROJECT: ${{ secrets.CLOUDFLARE_PAGES_PROJECT }}
+      CLOUDFLARE_PAGES_DEPLOY_HOOK: ${{ secrets.CLOUDFLARE_PAGES_DEPLOY_HOOK }}


### PR DESCRIPTION
## Summary

Moves the two Cloudflare Pages steps out of `.github/workflows/main-ci.yml`'s `release` job and into `kurkle/configs`' new reusable `docs-deploy.yml@v1`, called as a separate `docs-deploy` job. This is the same ~40-line Cloudflare block that was duplicated across five repos, now centralized.

Read `## Docs deploy workflow` in `kurkle/configs`' README directly from source (`gh api repos/kurkle/configs/contents/README.md`, not a local clone) and applied its three required changes to `release`:

1. Added a job-level `outputs:` block (next to `permissions:`, before `steps:`) forwarding the `release-version` step's own outputs as job outputs — `docs-deploy`'s `needs.release.outputs.*` can't resolve without this, since GitHub Actions doesn't expose a step's outputs to other jobs by default.
2. Removed the `Update Cloudflare Pages production docs version` and `Trigger Cloudflare Pages production deploy` steps — their logic now lives entirely in `docs-deploy.yml`.
3. Added the `docs-deploy` job, `needs: release`, gated on `needs.release.outputs.released == 'true'`, calling `kurkle/configs/.github/workflows/docs-deploy.yml@v1` with the four Cloudflare secrets named explicitly.

**Why only the Cloudflare part moves, not `release` itself:** npm's trusted publishing binds the publisher identity to the exact workflow **file name** that runs `npx semantic-release` — `main-ci.yml`. Moving that call into a called workflow would change the identity and break npm publishing fleet-wide. Only the two Cloudflare steps move; the `Resolve released version` step (`id: release-version`) stays in `release`, since it reads the git tag and belongs with the release itself, not the deploy.

**Why secrets are named explicitly, not `secrets: inherit`:** `inherit` would hand `docs-deploy.yml` every secret this repo has, including `NPM_TOKEN` and `CODECOV_TOKEN`, even though docs-deploy touches neither.

## Verification

- **`v1` tag actually points at configs' `main`:** `gh api repos/kurkle/configs/git/ref/tags/v1` → commit `9bbe1031068713980460e2707f9a7e2176a1f6f5`; `gh api repos/kurkle/configs/commits/main --jq '.sha'` → the same SHA.
- **`docs-deploy.yml` exists at that ref:** `gh api "repos/kurkle/configs/contents/.github/workflows/docs-deploy.yml?ref=v1"` returns it; also read its full contents to confirm its `workflow_call.inputs`/`secrets` declarations match what `main-ci.yml` now passes (one input, `version`; four required secrets, the same four named here).
- **`actionlint`**: clean on this file specifically and on the whole repo (`actionlint` with no args scans every workflow) — exit code 0 both times.
- **YAML validity**: parsed with Python's `yaml.safe_load` — valid, and inspected the parsed structure to confirm `release.outputs`, `docs-deploy.needs`, `docs-deploy.if`, `docs-deploy.with`, and `docs-deploy.secrets` all match what was intended, not just that the file parses.
- **Line count**: 95 lines before → 76 after (`git diff --numstat`: 14 insertions, 33 deletions; 95 − 33 + 14 = 76, confirmed against `git show origin/main:.github/workflows/main-ci.yml | wc -l` vs `wc -l` on the new file).
- **`Resolve released version` and `npx semantic-release` are still in the same file:** `grep -n "Resolve released version\|semantic-release\|id: release-version" .github/workflows/main-ci.yml` → both present, in the `release` job, unmoved.
- `npm test`: 142 unit/fixture specs (Chrome + Firefox), 3 browser-module integration specs, both Node integration tests — all green (this change doesn't touch anything test-related, but confirming nothing else broke).
- `npm run docs`: still builds 16 pages.
- Branch currency: branched from `origin/main`, `git rev-list --count HEAD..origin/main` → 0.

## What cannot be verified before an actual release

`actionlint` and YAML parsing confirm the workflow is syntactically valid and structurally matches the documented contract, but none of the following can be checked without a real merge to `main` that produces a release tag:

- That `docs-deploy`'s `if: needs.release.outputs.released == 'true'` actually evaluates correctly at runtime — i.e., that the job-level `outputs:` forwarding really does carry `release-version`'s step outputs through to `needs.release.outputs.*` in a dependent job, the way GitHub Actions' expression evaluation is documented to work. This is standard, well-documented GitHub Actions behavior, not something specific to this change, but I have not triggered an actual run.
- That the four secrets (`CLOUDFLARE_ACCOUNT_ID`, `CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_PAGES_PROJECT`, `CLOUDFLARE_PAGES_DEPLOY_HOOK`) are actually configured as repository secrets on `chartjs-chart-treemap` with the values the previous inline steps expected — I have no access to check secret values or even their existence from here.
- That the Cloudflare Pages API calls inside `docs-deploy.yml` actually succeed against this repo's Cloudflare project once invoked for real.
- That `docs-deploy` doesn't accidentally also run (or fail to run) on a non-release push to `main`, since `release.outputs.released` is only meaningfully `'true'` right after `semantic-release` actually cuts a release.

The next real release on this repo (a merge to `main` that triggers `semantic-release`) is the first point any of this becomes observable.

## Scope

Only `.github/workflows/main-ci.yml`. No other workflow files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
