### PR TITLE
chore: run build in prepack so published dist banners get the release version

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "lint": "biome check",
     "predocs": "npm run docs:version",
     "predocs:dev": "npm run docs:version",
+    "prepack": "npm run build",
     "prepare": "git config core.hooksPath .githooks || true",
     "pretest:unit": "swc --config-file .swcrc-spec src -d build",
     "test": "npm run test:unit && npm run test:fixture && npm run test:integration:browser-module && npm run test:integration:node-commonjs && npm run test:integration:node-module",


### PR DESCRIPTION
## Summary

- Add `prepack: npm run build` so `npm publish` rebuilds `dist/` right before packing, after semantic-release has already written the real version to `package.json`.
- Without this, the release job's earlier `npm run build` step bakes `0.0.0-development` into the dist file banners instead of the actual release version, since `npm run build` runs before `semantic-release` in `.github/workflows/main-ci.yml`.
- `chartjs-chart-sankey` already publishes correctly using this exact pattern (`v0.15.3` banner), while five other packages in the fleet show `v0.0.0-development` banners in their published bundles.
- Scope is intentionally a single script line — no changes to `main-ci.yml`, `.releaserc.json`, or the rollup config.

## Test plan

- [x] `npm run lint`
- [x] `npm test` (65 unit specs, 142 fixture tests, 3 browser-module integration tests, node-commonjs and node-module integration tests — all passing)
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `npm run docs`
- [x] Targeted proof: temporarily set `version` to `9.9.9`, ran `npm pack`, extracted the tarball, and confirmed `dist/chartjs-chart-treemap.cjs`, `.esm.js`, and `.min.js` banners all read `v9.9.9` (prepack rebuilt with the bumped version). Version reverted to `0.0.0-development` afterward, not committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)