### PR TITLE
ci: add a next prerelease channel and switch to the conventionalcommits preset

### DIFF
--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches:
       - main
+      # Prereleases (5.0.0-next.N) publish from here. npm's trusted publishing
+      # is bound to this workflow's filename, so the branch is added to the
+      # existing workflow rather than given one of its own.
+      - next
 
 permissions:
   contents: read
@@ -72,7 +76,9 @@ jobs:
 
   docs-deploy:
     needs: release
-    if: needs.release.outputs.released == 'true'
+    # Prereleases must not overwrite the published site while the previous
+    # major is still `latest`.
+    if: needs.release.outputs.released == 'true' && github.ref == 'refs/heads/main'
     uses: kurkle/configs/.github/workflows/docs-deploy.yml@v1
     with:
       version: ${{ needs.release.outputs.version }}

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -2,7 +2,7 @@ name: PR CI
 
 on:
   pull_request:
-    branches: [ main ]
+    branches: [ main, next ]
 
 permissions:
   contents: read

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,8 +1,8 @@
 {
-  "branches": ["main"],
+  "branches": ["main", { "name": "next", "prerelease": true }],
   "plugins": [
-    "@semantic-release/commit-analyzer",
-    "@semantic-release/release-notes-generator",
+    ["@semantic-release/commit-analyzer", { "preset": "conventionalcommits" }],
+    ["@semantic-release/release-notes-generator", { "preset": "conventionalcommits" }],
     "@semantic-release/npm",
     "@semantic-release/github"
   ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "chartjs-plugin-datalabels": "^2.2.0",
         "chartjs-plugin-zoom": "^2.0.0",
         "concurrently": "^10.0.3",
+        "conventional-changelog-conventionalcommits": "^10.4.0",
         "globals": "^17.0.0",
         "pixelmatch": "^7.1.0",
         "playwright": "^1.63.0",
@@ -1592,6 +1593,16 @@
       "optional": true,
       "engines": {
         "node": ">=0.1.90"
+      }
+    },
+    "node_modules/@conventional-changelog/template": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@conventional-changelog/template/-/template-1.4.0.tgz",
+      "integrity": "sha512-aalGyl7dbB5PArRebDIX43ZvBlXrYm9uWzGJ26t+4SzJVPsOuvfILGGbw5X4yX7i50YEmJ8zvbiWnqH/AAnZqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22"
       }
     },
     "node_modules/@ctrl/tinycolor": {
@@ -6780,6 +6791,19 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/conventional-changelog-conventionalcommits": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-10.4.0.tgz",
+      "integrity": "sha512-Rriac6ZrAlVm6cy9Bz4NSp+WMHpwNXoPIYex+HjCgduAVUSbnew29DQjQw0C4g9u3HtSYzGiGY+pdBXAZo+4aA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@conventional-changelog/template": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=22"
       }
     },
     "node_modules/conventional-changelog-writer": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "chartjs-plugin-datalabels": "^2.2.0",
     "chartjs-plugin-zoom": "^2.0.0",
     "concurrently": "^10.0.3",
+    "conventional-changelog-conventionalcommits": "^10.4.0",
     "globals": "^17.0.0",
     "pixelmatch": "^7.1.0",
     "playwright": "^1.63.0",


### PR DESCRIPTION
Release plumbing for the v5 plan. Nothing in `files` changes, so this releases nothing.

## The `next` channel

`next` becomes a semantic-release prerelease branch. PRs 1–9 of the v5 plan target it, each merge publishes `5.0.0-next.N` under the npm `next` dist-tag, and the reporters on #228 and #186 get something to try before the final tag. When the docs PR lands, `next` merges to `main` once and 5.0.0 is cut from the accumulated commits.

- The branch is added to `main-ci.yml` rather than given its own workflow: **npm's trusted publishing is bound to the workflow filename**, so a new file would break publishing.
- `docs-deploy` is now restricted to `main`. A prerelease must not overwrite the published site while 4.x is still `latest`.
- `pr-ci.yml` accepts pull requests targeting `next`.
- The `next` dist-tag currently points at `1.0.0-beta.4` from 2020; the first prerelease moves it.

## The preset change, and why it is not optional

`.releaserc.json` named no preset, so `@semantic-release/commit-analyzer` used **angular** — and angular does not understand the `!` breaking marker at all. Verified by running the installed analyzer against both presets:

| Commit | angular (before) | conventionalcommits (after) |
| --- | --- | --- |
| `feat!: data replaces tree` | **null** | major |
| `chore!: require chart.js 4` | **null** | major |
| `refactor!: move layout options to the dataset scope` | **null** | major |
| `feat: ...` + `BREAKING CHANGE:` footer | major | major |
| `feat: valueScale and others bucket` | minor | minor |
| `fix: ...` | patch | patch |
| `chore:` / `test:` / `docs:` / `ci:` | null | null |

`feat!:` did not merely fail to be treated as breaking. The angular header pattern is `^(\w*)(?:\((.*)\))?: (.*)$`, which `feat!:` does not match at all, so the commit was not recognised as a feature either and produced **no release whatsoever**. Every pull request title in the v5 plan uses `!`, so all of them would have merged silently and 5.0.0 would never have been cut.

The alternative was to keep angular and write `BREAKING CHANGE:` footers instead, but those have to survive GitHub's squash-merge message assembly, where commit bodies are folded into a bullet list. The marker in the subject line is the more robust of the two, and it is what the plan already assumes.

Non-releasing types are unaffected: `chore`, `test`, `docs`, `ci` and `refactor` without `!` still release nothing, so the rule that only `fix`, `feat` and `perf` (and now an explicit `!`) publish still holds.

Adds `conventional-changelog-conventionalcommits` as a dev dependency; the preset is not bundled with the analyzer.

## Verification

Both tables above come from running `analyzeCommits` from this branch's own `.releaserc.json`, not from reading documentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)