### PR TITLE
ci: pin the conventionalcommits preset to the major that matches semantic-release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "chartjs-plugin-datalabels": "^2.2.0",
         "chartjs-plugin-zoom": "^2.0.0",
         "concurrently": "^10.0.3",
-        "conventional-changelog-conventionalcommits": "^10.4.0",
+        "conventional-changelog-conventionalcommits": "^9.3.1",
         "globals": "^17.0.0",
         "pixelmatch": "^7.1.0",
         "playwright": "^1.63.0",
@@ -1593,16 +1593,6 @@
       "optional": true,
       "engines": {
         "node": ">=0.1.90"
-      }
-    },
-    "node_modules/@conventional-changelog/template": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@conventional-changelog/template/-/template-1.4.0.tgz",
-      "integrity": "sha512-aalGyl7dbB5PArRebDIX43ZvBlXrYm9uWzGJ26t+4SzJVPsOuvfILGGbw5X4yX7i50YEmJ8zvbiWnqH/AAnZqg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=22"
       }
     },
     "node_modules/@ctrl/tinycolor": {
@@ -6794,16 +6784,16 @@
       }
     },
     "node_modules/conventional-changelog-conventionalcommits": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-10.4.0.tgz",
-      "integrity": "sha512-Rriac6ZrAlVm6cy9Bz4NSp+WMHpwNXoPIYex+HjCgduAVUSbnew29DQjQw0C4g9u3HtSYzGiGY+pdBXAZo+4aA==",
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-9.3.1.tgz",
+      "integrity": "sha512-dTYtpIacRpcZgrvBYvBfArMmK2xvIpv2TaxM0/ZI5CBtNUzvF2x0t15HsbRABWprS6UPmvj+PzHVjSx4qAVKyw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "@conventional-changelog/template": "^1.4.0"
+        "compare-func": "^2.0.0"
       },
       "engines": {
-        "node": ">=22"
+        "node": ">=18"
       }
     },
     "node_modules/conventional-changelog-writer": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "chartjs-plugin-datalabels": "^2.2.0",
     "chartjs-plugin-zoom": "^2.0.0",
     "concurrently": "^10.0.3",
-    "conventional-changelog-conventionalcommits": "^10.4.0",
+    "conventional-changelog-conventionalcommits": "^9.3.1",
     "globals": "^17.0.0",
     "pixelmatch": "^7.1.0",
     "playwright": "^1.63.0",


### PR DESCRIPTION
Fixes the failing release job on `next`.

## What broke

My previous change switched the commit-analyzer preset to `conventionalcommits` and I verified it through **commit-analyzer only**. That was half the pipeline. The first real prerelease resolved the version correctly and then failed one step later:

```
[semantic-release] › ℹ  The next release version is 5.0.0-next.1
[semantic-release] › ✘  Failed step "generateNotes" of plugin "@semantic-release/release-notes-generator"
Error: Missing helper: "conventional-changelog-conventionalcommits requires
conventional-changelog-writer@9 or newer ... Update the tooling or use an
older major version of the preset."
```

## Root cause

`@semantic-release/release-notes-generator@14.1.1` pins `conventional-changelog-writer: ^8.0.0`, and semantic-release 25.0.9 is the current release, so the tooling cannot be updated.

**The preset majors are not aligned across preset families.** Writer 8 pairs with `conventional-changelog-angular@8` — but with `conventional-changelog-conventionalcommits@9`, not 10. Version 10 pulls in `@conventional-changelog/template`, which is what raises the error. Installing `@latest` gets 10 and looks correct right up until a release is actually cut.

## Fix and verification

Pinned to `^9.3.1`. This time both plugins were driven from the repository's own `.releaserc.json`, not just the analyzer:

| Commit | Release type | Notes |
| --- | --- | --- |
| `feat!: data replaces tree` | major | BREAKING CHANGES section |
| `chore!: require chart.js 4` | major | BREAKING CHANGES section |
| `refactor!: move layout options` | major | BREAKING CHANGES section |
| `feat: plain` | minor | rendered |
| `fix: plain` | patch | rendered |
| `test:` / `docs:` / `ci:` | no release | — |

The failure was **reproduced locally with 10.4.0** before the change and does not occur with 9.3.1. Sample output for the real `next` commit set:

```
## 5.0.0-next.1 (2026-09-08)

### ⚠ BREAKING CHANGES

* Chart.js 3 is no longer supported.
* the dividers option is removed.

### Features
* remove dividers
### Miscellaneous Chores
* require chart.js 4
```

## After merging

`next` needs this too. It is one commit ahead of `main` (`chore!: require chart.js 4`), so merging `main` into `next` propagates the fix and re-runs the release, which should then publish `5.0.0-next.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)