### PR TITLE
refactor: extract the layout into its own module

### DIFF
--- a/src/controller.ts
+++ b/src/controller.ts
@@ -1,100 +1,13 @@
+import type { LayoutOptions } from './layout'
+
 import { Chart, DatasetController, registry } from 'chart.js'
-import { clipArea, isObject, toFont, unclipArea, valueOrDefault } from 'chart.js/helpers'
+import { clipArea, unclipArea, valueOrDefault } from 'chart.js/helpers'
 
 import { version } from '../package.json'
 import { arrayNotEqual, rectNotEqual, scaleRect } from './helpers/index'
-import { layoutDefaults, parseBorderWidth } from './options'
-import squarify from './squarify'
-import { getCaptionHeight, shouldDrawCaption } from './text'
-import { getGroupKey, group, normalizeTreeToArray, requireVersion } from './utils'
-
-type LayoutOptions = {
-  borderWidth: any
-  captions: any
-  displayMode: string
-  groups: any[]
-  leafKey: string
-  spacing: number
-}
-
-function buildData(tree: any, keys: any[], mainRect: any, layout: LayoutOptions) {
-  const { borderWidth, captions, displayMode, groups, leafKey } = layout
-  if (isObject(tree)) {
-    tree = normalizeTreeToArray(keys, leafKey, tree)
-  }
-  const glen = groups.length
-  const sp = displayMode === 'headerBoxes' ? 0 : layout.spacing
-  const font = toFont(captions.font)
-  const padding = valueOrDefault(captions.padding, 3)
-
-  function getSubRect(sq: any, rect: any) {
-    const bw =
-      displayMode === 'headerBoxes'
-        ? { b: 0, l: 0, r: 0, t: 0 }
-        : parseBorderWidth(borderWidth, sq.w / 2, sq.h / 2)
-    const subRect = {
-      ...rect,
-      h: sq.h - 2 * sp - bw.t - bw.b,
-      w: sq.w - 2 * sp - bw.l - bw.r,
-      x: sq.x + sp + bw.l,
-      y: sq.y + sp + bw.t,
-    }
-    if (shouldDrawCaption(displayMode as any, subRect, captions)) {
-      const captionHeight = getCaptionHeight(displayMode as any, subRect, font, padding)
-      subRect.y += captionHeight
-      subRect.h -= captionHeight
-    }
-    return subRect
-  }
-
-  function recur(treeElements: any, gidx: number, rect: any, parent?: any, gs?: any) {
-    const g = getGroupKey(groups[gidx])
-    const gdata = group(
-      treeElements,
-      g,
-      keys,
-      leafKey,
-      undefined,
-      parent,
-      groups.filter((_item: any, index: number) => index <= gidx),
-      groups,
-      gidx
-    )
-    const gsq = squarify(gdata, rect, keys, g, gidx, gs)
-    const ret = gsq.slice()
-    if (gidx < glen - 1) {
-      gsq.forEach((sq) => {
-        const subRect = getSubRect(sq, rect)
-        const children: any[] = []
-        const nextGroupIndex = sq._data.groupIndex + 1
-        if (nextGroupIndex < glen) {
-          children.push(...recur(sq._data.children, nextGroupIndex, subRect, sq.g, sq.s))
-        }
-        ret.push(...children)
-        sq.isLeaf = !children.length
-      })
-    } else {
-      gsq.forEach((sq) => {
-        sq.isLeaf = true
-      })
-    }
-    return ret
-  }
-
-  const result = glen ? recur(tree, 0, mainRect) : squarify(tree, mainRect, keys)
-  return result
-    .map((d) => {
-      if (displayMode !== 'headerBoxes' || d.isLeaf) {
-        return d
-      }
-      if (!shouldDrawCaption(displayMode as any, d, captions)) {
-        return undefined
-      }
-      const captionHeight = getCaptionHeight(displayMode as any, d, font, padding)
-      return { ...d, h: captionHeight }
-    })
-    .filter(Boolean)
-}
+import { buildData } from './layout'
+import { layoutDefaults } from './options'
+import { requireVersion } from './utils'
 
 function registerTooltipPositioner() {
   const tooltipPlugin = registry.plugins.get('tooltip') as any

--- a/src/layout.ts
+++ b/src/layout.ts
@@ -1,0 +1,110 @@
+import type { DrawRect } from './geometry'
+import type { TreemapDataPoint, TreemapDisplayMode } from './types'
+
+import { isObject, toFont, valueOrDefault } from 'chart.js/helpers'
+
+import { parseBorderWidth } from './options'
+import squarify from './squarify'
+import { getCaptionHeight, shouldDrawCaption } from './text'
+import { getGroupKey, group, normalizeTreeToArray } from './utils'
+
+/**
+ * Turns the user's input into the flat list of rectangles the chart draws.
+ *
+ * Extracted from the controller unchanged: the recursion, the sub-rect
+ * calculation and the headerBoxes filtering are the same code, now behind a
+ * typed signature so the controller passes options in rather than the layout
+ * reaching into the dataset.
+ */
+export type LayoutOptions = {
+  borderWidth: any
+  captions: any
+  displayMode: TreemapDisplayMode
+  groups: any[]
+  leafKey: string
+  spacing: number
+}
+
+export function buildData(
+  tree: any,
+  keys: string[],
+  mainRect: DrawRect,
+  layout: LayoutOptions
+): TreemapDataPoint[] {
+  const { borderWidth, captions, displayMode, groups, leafKey } = layout
+  if (isObject(tree)) {
+    tree = normalizeTreeToArray(keys, leafKey, tree)
+  }
+  const glen = groups.length
+  const sp = displayMode === 'headerBoxes' ? 0 : layout.spacing
+  const font = toFont(captions.font)
+  const padding = valueOrDefault(captions.padding, 3)
+
+  function getSubRect(sq: any, rect: any) {
+    const bw =
+      displayMode === 'headerBoxes'
+        ? { b: 0, l: 0, r: 0, t: 0 }
+        : parseBorderWidth(borderWidth, sq.w / 2, sq.h / 2)
+    const subRect = {
+      ...rect,
+      h: sq.h - 2 * sp - bw.t - bw.b,
+      w: sq.w - 2 * sp - bw.l - bw.r,
+      x: sq.x + sp + bw.l,
+      y: sq.y + sp + bw.t,
+    }
+    if (shouldDrawCaption(displayMode, subRect, captions)) {
+      const captionHeight = getCaptionHeight(displayMode, subRect, font, padding)
+      subRect.y += captionHeight
+      subRect.h -= captionHeight
+    }
+    return subRect
+  }
+
+  function recur(treeElements: any, gidx: number, rect: any, parent?: any, gs?: any) {
+    const g = getGroupKey(groups[gidx])
+    const gdata = group(
+      treeElements,
+      g,
+      keys,
+      leafKey,
+      undefined,
+      parent,
+      groups.filter((_item: any, index: number) => index <= gidx),
+      groups,
+      gidx
+    )
+    const gsq = squarify(gdata, rect, keys, g, gidx, gs)
+    const ret = gsq.slice()
+    if (gidx < glen - 1) {
+      gsq.forEach((sq) => {
+        const subRect = getSubRect(sq, rect)
+        const children: any[] = []
+        const nextGroupIndex = sq._data.groupIndex + 1
+        if (nextGroupIndex < glen) {
+          children.push(...recur(sq._data.children, nextGroupIndex, subRect, sq.g, sq.s))
+        }
+        ret.push(...children)
+        sq.isLeaf = !children.length
+      })
+    } else {
+      gsq.forEach((sq) => {
+        sq.isLeaf = true
+      })
+    }
+    return ret
+  }
+
+  const result = glen ? recur(tree, 0, mainRect) : squarify(tree, mainRect, keys)
+  return result
+    .map((d) => {
+      if (displayMode !== 'headerBoxes' || d.isLeaf) {
+        return d
+      }
+      if (!shouldDrawCaption(displayMode, d, captions)) {
+        return undefined
+      }
+      const captionHeight = getCaptionHeight(displayMode, d, font, padding)
+      return { ...d, h: captionHeight }
+    })
+    .filter(Boolean)
+}


### PR DESCRIPTION
First half of feature 2, split out so the pipeline change reviews as a diff of its own. **No behaviour change.**

The recursion, the sub-rect calculation and the `headerBoxes` filtering are the same code, moved from `src/controller.ts` to `src/layout.ts` behind a typed signature. The controller now contains no layout logic at all.

## Verification

The 62 pixel fixtures and the 64 unit tests pass unchanged. An extraction that moved a pixel would fail them.

## What this unblocks, and one thing it revealed

Feature 2 replaces `tree` with `data` and makes the layout nodes the parsed data, which means the element count has to be known in `buildOrUpdateElements`. Checking when Chart.js actually calls that, by instrumenting a real chart rather than reading the bundle:

```
--- first update ---
  configure              options=set  _rect=UNDEFINED   <- scales not linked yet
  buildOrUpdateElements  options=set  _rect=UNDEFINED
  configure              options=set  _rect=set
--- second update ---
  buildOrUpdateElements  options=set  _rect=set         <- from the PREVIOUS update
  configure              options=set  _rect=set
```

`this.options` is available where the parse has to happen, but **the chart rect is not** — it is absent on the first update and stale afterwards. So the hierarchy pass and the geometry pass genuinely have to be separate, which is what the plan's design assumes and why it also moves `headerBoxes` filtering from "drop the node" to "hide the element": the number of parsed nodes must not depend on the rect.

That split is the next PR; this one just gets the code out of the controller first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)