### PR TITLE
refactor: split the layout into a hierarchy pass and a geometry pass

### DIFF
--- a/src/controller.ts
+++ b/src/controller.ts
@@ -112,6 +112,7 @@ export default class TreemapController extends DatasetController {
       // by an extra 0.5 and move 11 fixtures. Unifying the two is a visual
       // change that deserves its own pull request.
       spacing: valueOrDefault(dataset.spacing, 0),
+      unsorted: !!options.unsorted,
     }
   }
 

--- a/src/layout.test.ts
+++ b/src/layout.test.ts
@@ -1,0 +1,92 @@
+import type { DrawRect } from './geometry'
+import type { LayoutOptions } from './layout'
+
+import { buildData, buildNodes, flattenNodes } from './layout'
+
+const rect = (w: number, h: number) =>
+  ({
+    h,
+    radius: { bottomLeft: 0, bottomRight: 0, topLeft: 0, topRight: 0 },
+    w,
+    x: 0,
+    y: 0,
+  }) as DrawRect
+
+const options = (over: Partial<LayoutOptions> = {}): LayoutOptions => ({
+  borderWidth: 0,
+  captions: {},
+  displayMode: 'containerBoxes',
+  groups: [],
+  leafKey: '_leaf',
+  spacing: 0,
+  unsorted: false,
+  ...over,
+})
+
+const grouped = () => [
+  { grp: 'a', sub: 'p', value: 4 },
+  { grp: 'a', sub: 'q', value: 3 },
+  { grp: 'b', sub: 'p', value: 2 },
+  { grp: 'b', sub: 'q', value: 1 },
+]
+
+describe('layout', () => {
+  it('builds the hierarchy without a rectangle at all', () => {
+    const nodes = flattenNodes(
+      buildNodes(grouped(), ['value'], options({ groups: ['grp', 'sub'] }))
+    )
+
+    // No chart area was involved, yet the count, the order and the values are
+    // final. This is what lets the controller create its elements before the
+    // layout has anywhere to put them.
+    expect(nodes.length).toBe(6)
+    expect(nodes.map((n) => n.g)).toEqual(['a', 'b', 'p', 'q', 'p', 'q'])
+    expect(nodes.map((n) => n.v)).toEqual([7, 3, 4, 3, 2, 1])
+    expect(nodes.every((n) => n.x === undefined && n.w === undefined)).toBe(true)
+  })
+
+  it('produces the same nodes whatever the chart area', () => {
+    const opts = options({ groups: ['grp', 'sub'] })
+    const small = buildData(grouped(), ['value'], rect(10, 10), opts)
+    const large = buildData(grouped(), ['value'], rect(2000, 1000), opts)
+
+    expect(large.length).toBe(small.length)
+    expect(large.map((n) => [n.g, n.l, n.v])).toEqual(small.map((n) => [n.g, n.l, n.v]))
+  })
+
+  it('orders nodes as siblings first, then each sibling’s descendants', () => {
+    const opts = options({ groups: ['grp', 'sub'] })
+    const nodes = buildData(grouped(), ['value'], rect(400, 300), opts)
+
+    expect(nodes.map((n) => n.g)).toEqual(['a', 'b', 'p', 'q', 'p', 'q'])
+    expect(nodes.map((n) => n.l)).toEqual([0, 0, 1, 1, 1, 1])
+    expect(nodes.map((n) => n.isLeaf)).toEqual([false, false, true, true, true, true])
+  })
+
+  it('sizes groups by the sum of their children and children by their parent', () => {
+    const opts = options({ groups: ['grp', 'sub'] })
+    const nodes = buildData(grouped(), ['value'], rect(400, 300), opts)
+    const [a, b] = nodes
+
+    expect(a.v).toBe(7)
+    expect(b.v).toBe(3)
+    // every child fits inside the parent it was laid out into
+    for (const child of nodes.slice(2, 4)) {
+      expect(child.x).toBeGreaterThanOrEqual(a.x)
+      expect(child.x + child.w).toBeLessThanOrEqual(a.x + a.w + 1e-9)
+    }
+  })
+
+  it('leaves ungrouped values without group fields', () => {
+    const nodes = buildData([3, 1, 2], [''], rect(300, 200), options())
+
+    expect(nodes.map((n) => n.v)).toEqual([3, 2, 1])
+    expect(nodes.every((n) => n.g === undefined && n.l === undefined)).toBe(true)
+  })
+
+  it('keeps the input order when unsorted', () => {
+    const nodes = buildData([3, 1, 2], [''], rect(300, 200), options({ unsorted: true }))
+
+    expect(nodes.map((n) => n.v)).toEqual([3, 1, 2])
+  })
+})

--- a/src/layout.ts
+++ b/src/layout.ts
@@ -4,18 +4,10 @@ import type { TreemapDataPoint, TreemapDisplayMode } from './types'
 import { isObject, toFont, valueOrDefault } from 'chart.js/helpers'
 
 import { parseBorderWidth } from './options'
-import squarify from './squarify'
+import { packInto, sortNodes, toNodes } from './squarify'
 import { getCaptionHeight, shouldDrawCaption } from './text'
 import { getGroupKey, group, normalizeTreeToArray } from './utils'
 
-/**
- * Turns the user's input into the flat list of rectangles the chart draws.
- *
- * Extracted from the controller unchanged: the recursion, the sub-rect
- * calculation and the headerBoxes filtering are the same code, now behind a
- * typed signature so the controller passes options in rather than the layout
- * reaching into the dataset.
- */
 export type LayoutOptions = {
   borderWidth: any
   captions: any
@@ -23,80 +15,159 @@ export type LayoutOptions = {
   groups: any[]
   leafKey: string
   spacing: number
+  unsorted: boolean
 }
 
+/** A node while the layout is being built; `_children` is dropped before use. */
+export type LayoutNode = TreemapDataPoint & { _children?: LayoutNode[] }
+
+/**
+ * Pass one: the hierarchy.
+ *
+ * Groups the items level by level and orders each set of siblings. Nothing here
+ * depends on the chart area, so the number of nodes and their order are known
+ * before the layout has a rectangle to fill.
+ */
+function buildHierarchy(
+  values: any[],
+  gidx: number,
+  keys: string[],
+  layout: LayoutOptions,
+  parentGroupValue?: string
+): LayoutNode[] {
+  const { groups, leafKey, unsorted } = layout
+  const glen = groups.length
+  const g = getGroupKey(groups[gidx])
+  const gdata = group(
+    values,
+    g,
+    keys,
+    leafKey,
+    undefined,
+    parentGroupValue,
+    groups.filter((_item: any, index: number) => index <= gidx),
+    groups,
+    gidx
+  )
+  const nodes = toNodes(gdata, keys, g, gidx) as LayoutNode[]
+  if (!unsorted) {
+    sortNodes(nodes)
+  }
+
+  for (const node of nodes) {
+    const record = node._data as any
+    const nextGroupIndex = record.groupIndex + 1
+    const children =
+      gidx < glen - 1 && nextGroupIndex < glen
+        ? buildHierarchy(record.children, nextGroupIndex, keys, layout, node.g)
+        : []
+    node._children = children
+    node.isLeaf = !children.length
+  }
+  return nodes
+}
+
+/** Draw order: a set of siblings, then the descendants of each in turn. */
+export function flattenNodes(nodes: LayoutNode[]): LayoutNode[] {
+  const flat = nodes.slice()
+  for (const node of nodes) {
+    if (node._children?.length) {
+      flat.push(...flattenNodes(node._children))
+    }
+  }
+  return flat
+}
+
+/**
+ * Pass two: the geometry.
+ *
+ * Packs each set of siblings into its parent's rectangle, writing the
+ * coordinates onto the nodes the first pass produced.
+ */
+export function layoutNodes(
+  nodes: LayoutNode[],
+  rect: any,
+  layout: LayoutOptions,
+  parentSum?: number
+) {
+  if (parentSum !== undefined) {
+    for (const node of nodes) {
+      node.gs = parentSum
+    }
+  }
+  packInto(nodes, rect)
+
+  for (const node of nodes) {
+    if (node._children?.length) {
+      layoutNodes(node._children, getSubRect(node, rect, layout), layout, node.s)
+    }
+  }
+}
+
+/** The rectangle left for a group's children once its border and caption are taken. */
+function getSubRect(sq: any, rect: any, layout: LayoutOptions) {
+  const { borderWidth, captions, displayMode } = layout
+  const sp = displayMode === 'headerBoxes' ? 0 : layout.spacing
+  const bw =
+    displayMode === 'headerBoxes'
+      ? { b: 0, l: 0, r: 0, t: 0 }
+      : parseBorderWidth(borderWidth, sq.w / 2, sq.h / 2)
+  const subRect = {
+    ...rect,
+    h: sq.h - 2 * sp - bw.t - bw.b,
+    w: sq.w - 2 * sp - bw.l - bw.r,
+    x: sq.x + sp + bw.l,
+    y: sq.y + sp + bw.t,
+  }
+  if (shouldDrawCaption(displayMode, subRect, captions)) {
+    const captionHeight = getCaptionHeight(
+      displayMode,
+      subRect,
+      toFont(captions.font),
+      valueOrDefault(captions.padding, 3)
+    )
+    subRect.y += captionHeight
+    subRect.h -= captionHeight
+  }
+  return subRect
+}
+
+/**
+ * The hierarchy pass on its own: the nested nodes, in draw order, with no
+ * geometry. Takes no rectangle, which is the whole point - the controller needs
+ * the node count before the chart area is known.
+ */
+export function buildNodes(tree: any, keys: string[], layout: LayoutOptions): LayoutNode[] {
+  const { groups, leafKey, unsorted } = layout
+  const input = isObject(tree) ? normalizeTreeToArray(keys, leafKey, tree) : tree
+
+  if (groups.length) {
+    return buildHierarchy(input, 0, keys, layout)
+  }
+  const nodes = toNodes(input || [], keys) as LayoutNode[]
+  if (!unsorted) {
+    sortNodes(nodes)
+  }
+  return nodes
+}
+
+/** Turns the user's input into the flat list of rectangles the chart draws. */
 export function buildData(
   tree: any,
   keys: string[],
   mainRect: DrawRect,
   layout: LayoutOptions
 ): TreemapDataPoint[] {
-  const { borderWidth, captions, displayMode, groups, leafKey } = layout
-  if (isObject(tree)) {
-    tree = normalizeTreeToArray(keys, leafKey, tree)
-  }
-  const glen = groups.length
-  const sp = displayMode === 'headerBoxes' ? 0 : layout.spacing
+  const { captions, displayMode } = layout
+  const nodes = buildNodes(tree, keys, layout)
+  layoutNodes(nodes, mainRect, layout)
+
   const font = toFont(captions.font)
   const padding = valueOrDefault(captions.padding, 3)
-
-  function getSubRect(sq: any, rect: any) {
-    const bw =
-      displayMode === 'headerBoxes'
-        ? { b: 0, l: 0, r: 0, t: 0 }
-        : parseBorderWidth(borderWidth, sq.w / 2, sq.h / 2)
-    const subRect = {
-      ...rect,
-      h: sq.h - 2 * sp - bw.t - bw.b,
-      w: sq.w - 2 * sp - bw.l - bw.r,
-      x: sq.x + sp + bw.l,
-      y: sq.y + sp + bw.t,
-    }
-    if (shouldDrawCaption(displayMode, subRect, captions)) {
-      const captionHeight = getCaptionHeight(displayMode, subRect, font, padding)
-      subRect.y += captionHeight
-      subRect.h -= captionHeight
-    }
-    return subRect
-  }
-
-  function recur(treeElements: any, gidx: number, rect: any, parent?: any, gs?: any) {
-    const g = getGroupKey(groups[gidx])
-    const gdata = group(
-      treeElements,
-      g,
-      keys,
-      leafKey,
-      undefined,
-      parent,
-      groups.filter((_item: any, index: number) => index <= gidx),
-      groups,
-      gidx
-    )
-    const gsq = squarify(gdata, rect, keys, g, gidx, gs)
-    const ret = gsq.slice()
-    if (gidx < glen - 1) {
-      gsq.forEach((sq) => {
-        const subRect = getSubRect(sq, rect)
-        const children: any[] = []
-        const nextGroupIndex = sq._data.groupIndex + 1
-        if (nextGroupIndex < glen) {
-          children.push(...recur(sq._data.children, nextGroupIndex, subRect, sq.g, sq.s))
-        }
-        ret.push(...children)
-        sq.isLeaf = !children.length
-      })
-    } else {
-      gsq.forEach((sq) => {
-        sq.isLeaf = true
-      })
-    }
-    return ret
-  }
-
-  const result = glen ? recur(tree, 0, mainRect) : squarify(tree, mainRect, keys)
-  return result
+  return flattenNodes(nodes)
     .map((d) => {
+      // The nested link is internal; it must not reach ctx.raw.
+      delete d._children
       if (displayMode !== 'headerBoxes' || d.isLeaf) {
         return d
       }
@@ -106,5 +177,5 @@ export function buildData(
       const captionHeight = getCaptionHeight(displayMode, d, font, padding)
       return { ...d, h: captionHeight }
     })
-    .filter(Boolean)
+    .filter(Boolean) as TreemapDataPoint[]
 }

--- a/src/rect.ts
+++ b/src/rect.ts
@@ -11,24 +11,15 @@ function getDims(itm: any, w2: number, s2: number, key: string) {
 
 const getX = (rect: Rect, w: number) => (rect.rtl ? rect.x + rect.iw - w : rect.x + rect._ix)
 
-function buildRow(rect: Rect, itm: any, dims: any, sum: number) {
-  const r: Record<string, any> = {
-    _data: itm._data,
-    a: itm._normalized,
-    h: dims.h,
-    s: sum,
-    v: itm.value,
-    vs: itm.values,
-    w: dims.w,
-    x: getX(rect, dims.w),
-    y: rect.y + rect._iy,
-  }
-  if (itm.group) {
-    r.g = itm.group
-    r.l = itm.level
-    r.gs = itm.groupSum
-  }
-  return r
+/** Writes the geometry of one packed row onto the nodes themselves. */
+function assignRow(rect: Rect, itm: any, dims: any, sum: number) {
+  itm.a = itm._normalized
+  itm.h = dims.h
+  itm.s = sum
+  itm.w = dims.w
+  itm.x = getX(rect, dims.w)
+  itm.y = rect.y + rect._iy
+  delete itm._normalized
 }
 
 export default class Rect {
@@ -82,19 +73,17 @@ export default class Rect {
     const row = arr.get()
     const w2 = side * side
     const s2 = sum * sum
-    const ret: any[] = []
     let maxd2 = 0
     let totd1 = 0
     for (const itm of row) {
       const dims = getDims(itm, w2, s2, key)
       totd1 += dims.d1
       maxd2 = Math.max(maxd2, dims.d2)
-      ret.push(buildRow(this, itm, dims, arr.sum))
+      assignRow(this, itm, dims, arr.sum)
       this[key] += dims.d1
     }
 
     this[dir === 'x' ? '_iy' : '_ix'] += maxd2
     this[key] -= totd1
-    return ret
   }
 }

--- a/src/squarify.ts
+++ b/src/squarify.ts
@@ -1,6 +1,6 @@
 import Rect from './rect'
 import StatArray from './statArray'
-import { flatten, index, sort, sum } from './utils'
+import { index, sort, sum } from './utils'
 
 function compareAspectRatio(oldStat: any, newStat: any, args: any[]) {
   if (oldStat.sum === 0) {
@@ -16,6 +16,69 @@ function compareAspectRatio(oldStat: any, newStat: any, args: any[]) {
   return nr <= or
 }
 
+/**
+ * Builds the nodes for one set of siblings, without any geometry.
+ *
+ * Everything here depends only on the data: which item a node came from, its
+ * value, its group and level. The rectangle is not involved, which is what lets
+ * the controller know how many elements it needs before the chart area is known.
+ */
+export function toNodes(values: any[], keys: string[], grp?: string, lvl?: number) {
+  const items = values ? values.slice() : []
+  const key = index(items, keys[0])
+
+  return items.map((item: any) => {
+    const node: any = {
+      _data: values[item._idx],
+      v: key ? +item[key] : +item,
+      vs: undefined,
+    }
+    if (grp) {
+      node.g = item[grp]
+      node.gs = undefined
+      node.l = item.groupIndex ?? lvl
+      node.vs = keys.reduce<Record<string, number>>((obj, k) => {
+        obj[k] = +item[k]
+        return obj
+      }, {})
+    }
+    return node
+  })
+}
+
+/** Orders a set of siblings the way the layout draws them: largest first. */
+export function sortNodes(nodes: any[]) {
+  sort(nodes, 'v')
+}
+
+/**
+ * Packs already-ordered nodes into the rectangle, writing `x`, `y`, `w`, `h`,
+ * the row sum `s` and the normalized area `a` onto them.
+ */
+export function packInto(nodes: any[], rectangle: any) {
+  const n = nodes.length
+  if (!n) {
+    return
+  }
+  const rect = new Rect(rectangle)
+  const row = new StatArray('v', rect.area / sum(nodes, 'v'))
+  let length = rect.side
+  let o: any
+
+  for (let i = 0; i < n; ++i) {
+    o = row.pushIf(nodes[i], compareAspectRatio, length)
+    if (o) {
+      rect.map(row)
+      length = rect.side
+      row.reset()
+      row.push(o)
+    }
+  }
+  if (row.length) {
+    rect.map(row)
+  }
+}
+
 export default function squarify(
   values: any[],
   rectangle: any,
@@ -24,56 +87,15 @@ export default function squarify(
   lvl?: number,
   gsum?: number
 ) {
-  values = values || []
-  const rows: any[] = []
-  const rect = new Rect(rectangle)
-  const row = new StatArray('value', rect.area / sum(values, keys[0]))
-  let length = rect.side
-  const n = values.length
-  let i: number
-  let o: any
-
-  if (!n) {
-    return rows
+  const nodes = toNodes(values || [], keys, grp, lvl)
+  if (grp) {
+    for (const node of nodes) {
+      node.gs = gsum
+    }
   }
-
-  const tmp = values.slice()
-  const key = index(tmp, keys[0])
-
   if (!rectangle?.unsorted) {
-    sort(tmp, key)
+    sortNodes(nodes)
   }
-
-  const val = (idx: number) => (key ? +tmp[idx][key] : +tmp[idx])
-  const gval = (idx: number) => grp && tmp[idx][grp]
-
-  for (i = 0; i < n; ++i) {
-    o = {
-      _data: values[tmp[i]._idx],
-      group: undefined,
-      groupSum: gsum,
-      level: undefined,
-      value: val(i),
-    }
-    if (grp) {
-      o.level = tmp[i].groupIndex ?? lvl
-      o.group = gval(i)
-      const tmpRef = tmp[i]
-      o.values = keys.reduce<Record<string, number>>((obj, k) => {
-        obj[k] = +tmpRef[k]
-        return obj
-      }, {})
-    }
-    o = row.pushIf(o, compareAspectRatio, length)
-    if (o) {
-      rows.push(rect.map(row))
-      length = rect.side
-      row.reset()
-      row.push(o)
-    }
-  }
-  if (row.length) {
-    rows.push(rect.map(row))
-  }
-  return flatten(rows)
+  packInto(nodes, rectangle)
+  return nodes
 }


### PR DESCRIPTION
The restructure that makes feature 2 possible. **No API change and no pixel moves.**

## Why it has to happen first

`buildData` interleaved two jobs: `recur()` grouped one level, immediately squarified it into the parent's rectangle, then recursed into the geometry it had just produced. That is why the element count could not be known without a chart area — and, as [#462](https://github.com/kurkle/chartjs-chart-treemap/pull/462) established by instrumenting a real chart, a chart area is exactly what is *not* available where `buildOrUpdateElements` runs.

## The seam

| | takes a rectangle | produces |
| --- | --- | --- |
| `buildNodes()` | **no** | the nested nodes, grouped and ordered, with `_data`, `v`, `vs`, `g`, `l`, `isLeaf` |
| `layoutNodes()` | yes | writes `x`, `y`, `w`, `h`, `s`, `a`, `gs` onto those same nodes |
| `buildData()` | yes | composes the two; unchanged from the caller's side |

`squarify` gained the same seam: `toNodes()` builds a set of siblings from the data, `sortNodes()` orders them, `packInto()` writes the geometry onto them. The default export composes those three, so **its signature and its 190 lines of geometry tests are untouched**. `Rect.map` assigns onto the nodes instead of building new objects.

## Three fields turned out to be geometry, not hierarchy

Worth knowing before feature 2 builds on this, because their names suggest otherwise:

```
s   the sum of the packed ROW, not of all siblings
a   the value normalized against the rectangle's area
gs  the parent's s, so it inherits the same dependency
```

All three are written in the second pass. Only `_data`, `v`, `vs`, `g`, `l` and `isLeaf` come out of the first. The plan's node sketch describes `s` as "sibling sum", which is not what the code computes — flagging it so the sketch gets corrected rather than implemented.

## Verification

- **The 62 pixel fixtures pass unchanged in both browsers**, run twice. A restructure of the packing that moved a rectangle would fail them, and squarify's own geometry unit tests would fail before that.
- Six new unit tests cover the seam, including the one that states the point directly: the hierarchy is complete and correctly ordered with **no rectangle in sight**, and the nodes have no `x`/`w` yet.
- Unit coverage 72 % → 78 %; `layout.ts` goes from untested to 93 %.

🤖 Generated with [Claude Code](https://claude.com/claude-code)