### PR TITLE
feat!: data replaces tree, and the layout nodes are the parsed data

### DIFF
--- a/bench/update.mjs
+++ b/bench/update.mjs
@@ -5,6 +5,10 @@
  * grouping recursion runs whether or not anything changed. This measures what
  * that costs, and where it overtakes what v4 did.
  *
+ * The dominant cost at this size is not ours: about half of an update is
+ * Chart.js resolving element options once per element, because option sharing
+ * never engages for this element type. See the pull request for the analysis.
+ *
  *   npm run bench
  */
 import { createCanvas } from '@napi-rs/canvas'

--- a/bench/update.mjs
+++ b/bench/update.mjs
@@ -1,0 +1,95 @@
+/**
+ * Update cost against data size.
+ *
+ * v5 parses on every update instead of waiting for a `treeVersion` bump, so the
+ * grouping recursion runs whether or not anything changed. This measures what
+ * that costs, and where it overtakes what v4 did.
+ *
+ *   npm run bench
+ */
+import { createCanvas } from '@napi-rs/canvas'
+import { Chart, LinearScale, Tooltip } from 'chart.js'
+
+import { TreemapController, TreemapElement } from '../dist/chartjs-chart-treemap.esm.js'
+
+Chart.register(LinearScale, Tooltip, TreemapController, TreemapElement)
+
+const median = (values) => values.slice().sort((a, b) => a - b)[Math.floor(values.length / 2)]
+
+function time(runs, fn) {
+  const samples = []
+  for (let i = 0; i < runs; i++) {
+    const start = performance.now()
+    fn()
+    samples.push(performance.now() - start)
+  }
+  return median(samples)
+}
+
+function rows(count, levels) {
+  const out = []
+  const width = Math.max(1, Math.round(Math.sqrt(count)))
+  for (let i = 0; i < count; i++) {
+    const row = { value: 1 + (i % 97) }
+    if (levels > 0) {
+      row.g1 = `g${i % width}`
+    }
+    if (levels > 1) {
+      row.g2 = `s${i % 7}`
+    }
+    out.push(row)
+  }
+  return out
+}
+
+function measure(count, groups) {
+  const data = rows(count, groups.length)
+  const canvas = createCanvas(800, 600)
+  const ctx = canvas.getContext('2d')
+  ctx.canvas = canvas
+
+  const start = performance.now()
+  const chart = new Chart(ctx, {
+    data: { datasets: [{ data, groups, key: 'value' }] },
+    options: { animation: false, plugins: { legend: false, tooltip: false }, responsive: false },
+    type: 'treemap',
+  })
+  const create = performance.now() - start
+  const nodes = chart.getDatasetMeta(0)._parsed.length
+
+  // The zoom plugin's case: an update per wheel event with nothing changed.
+  const idle = time(9, () => chart.update('none'))
+
+  let n = 0
+  const edited = time(9, () => {
+    data[0].value = 1 + (n++ % 90)
+    chart.update('none')
+  })
+
+  chart.destroy()
+  return { create, edited, idle, nodes }
+}
+
+const pad = (value, width) => String(value).padEnd(width)
+
+console.log(
+  pad('rows', 9) +
+    pad('groups', 8) +
+    pad('nodes', 9) +
+    pad('create', 11) +
+    pad('update, idle', 15) +
+    'update, edited'
+)
+for (const count of [1000, 10000, 50000]) {
+  for (const groups of [[], ['g1', 'g2']]) {
+    const r = measure(count, groups)
+    console.log(
+      pad(count, 9) +
+        pad(groups.length, 8) +
+        pad(r.nodes, 9) +
+        pad(`${r.create.toFixed(1)} ms`, 11) +
+        pad(`${r.idle.toFixed(1)} ms`, 15) +
+        `${r.edited.toFixed(1)} ms`
+    )
+  }
+}

--- a/biome.json
+++ b/biome.json
@@ -3,6 +3,7 @@
   "files": {
     "includes": [
       "astro.config.mjs",
+      "bench/**/*.mjs",
       "biome.json",
       "docs/scripts/**/*.js",
       "docs/src/**/*.astro",

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
   },
   "scripts": {
     "autobuild": "rollup -c -w",
+    "bench": "node bench/update.mjs",
     "build": "rollup -c && tsc -p tsconfig.json --emitDeclarationOnly",
     "dev": "vitest --config vitest.browser.config.ts",
     "docs": "npm run build && astro build",

--- a/src/content/docs/samples/basic.md
+++ b/src/content/docs/samples/basic.md
@@ -32,7 +32,7 @@ const config = {
     datasets: [
       {
         label: 'My First dataset',
-        tree: Utils.numbers(NUMBER_CFG),
+        data: Utils.numbers(NUMBER_CFG),
         borderColor: (ctx) => colorFromRaw(ctx, true),
         borderWidth: 1,
         spacing: -0.5, // Animations look better when overlapping a little

--- a/src/content/docs/samples/captions.md
+++ b/src/content/docs/samples/captions.md
@@ -45,7 +45,7 @@ const config = {
   type: 'treemap',
   data: {
     datasets: [{
-      tree: Data.statsByState,
+      data: Data.statsByState,
       key: 'area',
       groups: GROUPS,
       spacing: 1,

--- a/src/content/docs/samples/datalabels.md
+++ b/src/content/docs/samples/datalabels.md
@@ -32,7 +32,7 @@ const config = {
     datasets: [
       {
         label: 'My First dataset',
-        tree: Utils.numbers(NUMBER_CFG),
+        data: Utils.numbers(NUMBER_CFG),
         borderColor: (ctx) => colorFromRaw(ctx, true),
         borderWidth: 1,
         spacing: 0,
@@ -41,7 +41,11 @@ const config = {
           display: 'auto',
           anchor: 'start',
           align: 45,
-          formatter: (value) => Math.trunc(value.v),
+          // In v5 `dataset.data` holds the rows you passed, so the datalabels
+          // formatter's first argument is no longer a layout node. Read the
+          // node through the controller instead.
+          formatter: (_value, ctx) =>
+            Math.trunc(ctx.chart.getDatasetMeta(ctx.datasetIndex).controller.getParsed(ctx.dataIndex).v),
           color: 'white',
           font: {
             size: 20

--- a/src/content/docs/samples/displayMode.md
+++ b/src/content/docs/samples/displayMode.md
@@ -43,7 +43,7 @@ const config = {
   type: 'treemap',
   data: {
     datasets: [{
-      tree: Data.statsByState,
+      data: Data.statsByState,
       key: 'area',
       groups: ['division', 'state'],
       spacing: 2,

--- a/src/content/docs/samples/groups.md
+++ b/src/content/docs/samples/groups.md
@@ -43,7 +43,7 @@ const config = {
   type: 'treemap',
   data: {
     datasets: [{
-      tree: Data.statsByState,
+      data: Data.statsByState,
       key: 'area',
       groups: GROUPS,
       spacing: 1,

--- a/src/content/docs/samples/labels.md
+++ b/src/content/docs/samples/labels.md
@@ -38,7 +38,7 @@ const config = {
     datasets: [
       {
         label: 'My First dataset',
-        tree: Utils.numbers(NUMBER_CFG),
+        data: Utils.numbers(NUMBER_CFG),
         borderColor: 'red',
         borderWidth: 0.5,
         spacing: 0,

--- a/src/content/docs/samples/labelsFontsAndColors.md
+++ b/src/content/docs/samples/labelsFontsAndColors.md
@@ -46,7 +46,7 @@ const config = {
     datasets: [
       {
         label: 'Fruits',
-        tree: DATA,
+        data: DATA,
         key: 'value',
         borderWidth: 0,
         borderRadius: 6,

--- a/src/content/docs/samples/missingGroups.md
+++ b/src/content/docs/samples/missingGroups.md
@@ -47,7 +47,7 @@ const config = {
   type: 'treemap',
   data: {
     datasets: [{
-      tree: data,
+      data: data,
       key: 'value',
       groups: ['folder', 'component', 'subFolder', 'file'],
       spacing: 2,

--- a/src/content/docs/samples/outlining-groups.md
+++ b/src/content/docs/samples/outlining-groups.md
@@ -29,7 +29,7 @@ const config = {
   type: 'treemap',
   data: {
     datasets: [{
-      tree: Data.statsByState,
+      data: Data.statsByState,
       key: 'area',
       groups: GROUPS,
       spacing: 1,

--- a/src/content/docs/samples/rtl.md
+++ b/src/content/docs/samples/rtl.md
@@ -44,7 +44,7 @@ const config = {
   type: 'treemap',
   data: {
     datasets: [{
-      tree: Data.statsByState,
+      data: Data.statsByState,
       key: 'area',
       groups: ['state'],
       spacing: -0.5,

--- a/src/content/docs/samples/tree.md
+++ b/src/content/docs/samples/tree.md
@@ -30,7 +30,7 @@ const config = {
   type: 'treemap',
   data: {
     datasets: [{
-      tree: Data.objectsTree,
+      data: Data.objectsTree,
       leafKey: 'name',
       key: 'value',
       groups: [],

--- a/src/content/docs/samples/zoom.md
+++ b/src/content/docs/samples/zoom.md
@@ -32,7 +32,7 @@ const config = {
     datasets: [
       {
         label: 'My First dataset',
-        tree: Utils.numbers(NUMBER_CFG),
+        data: Utils.numbers(NUMBER_CFG),
         borderWidth: 0,
         backgroundColor: (ctx) => colorFromRaw(ctx),
         labels: {

--- a/src/content/docs/usage.md
+++ b/src/content/docs/usage.md
@@ -24,7 +24,7 @@ const config = {
     datasets: [
       {
         label: 'My treemap dataset',
-        tree: [15, 6, 6, 5, 4, 3, 2, 2],
+        data: [15, 6, 6, 5, 4, 3, 2, 2],
         borderColor: 'green',
         borderWidth: 1,
         spacing: 0,
@@ -82,6 +82,7 @@ are element options and are resolved per element, so they can be
 | [`borderRadius`](#styling) | `number` \| `object` | Yes | `0`
 | [`borderWidth`](#styling) | `number`\|`object` | - | `0`
 | [`captions`](#captions) | `object` | - |
+| [`data`](#general) | `number[]` \| `object[]` \| `object` | - |  **required**
 | [`groups`](#general) | `string[]` | - | `undefined` |
 | [`hoverBackgroundColor`](#interactions) | [`Color`](https://www.chartjs.org/docs/latest/general/colors.html) | Yes | `undefined`
 | [`hoverBorderColor`](#interactions) | [`Color`](https://www.chartjs.org/docs/latest/general/colors.html) | Yes | `undefined`
@@ -92,9 +93,7 @@ are element options and are resolved per element, so they can be
 | [`rtl`](#general) | `boolean` | - | `false`
 | [`spacing`](#styling) | `number` | - | `0.5`
 | [`sumKeys`](#general) | `string[]` | - | `undefined` |
-| [`tree`](#general) | `number[]` \| `object[]` \| `object` | - |  **required**
 | [`leafKey`](#general) | `string` | - | `_leaf` |
-| [`treeVersion`](#general) | `number` \| `string` | - | `undefined` |
 | [`unsorted`](#general) | `boolean` | - | `false`
 | [`displayMode`](#styling) | `string` | - | `'containerBoxes'`
 
@@ -104,17 +103,16 @@ All these values, if `undefined`, fallback to the scopes described in [option re
 
 | Name | Description
 | ---- | ----
+| `data` | Numbers, objects, or a nested object addressed through `leafKey`. The array is read, never written.
 | `groups` | Define how to display multiple levels of hierarchy. Data is summarized to groups internally.
 | `key` | Define the key name in data objects to use for value.
 | `label` | The label for the dataset which appears in the legend and tooltips.
 | `rtl` | If `true`, the treemap elements are rendering from right to left.
 | `sumKeys` | Define multiple keys to add additional sums, on top of the `key` one, for scriptable options use.
-| `tree` | Tree data should be provided in `tree` property of dataset. `data` is then automatically built.
-| `leafKey` | The name of the key where the object key of leaf node of tree object is stored. Used only when `tree` is an `object`, as hierarchical data.
-| `treeVersion` | Change this value when mutating `tree` in place to rebuild the generated data on the next chart update.
+| `leafKey` | The name of the key where the object key of a leaf node is stored. Used only when `data` is a nested `object`.
 | `unsorted` | If `true`, treemap elements are rendered unsorted.
 
-`displayMode`, `groups`, `key`, `leafKey`, `rtl`, `spacing`, `sumKeys`, `tree` and
+`data`, `displayMode`, `groups`, `key`, `leafKey`, `rtl`, `spacing`, `sumKeys` and
 `unsorted` are dataset options: set them on the dataset or in `options.datasets.treemap`.
 Setting them in `options.elements.treemap` has no effect.
 
@@ -125,251 +123,44 @@ room is left inside a group for its children, so they are read once while the la
 built rather than per element. A scriptable `borderWidth` still draws per element, but the
 space reserved for the children uses the dataset-level value.
 
+### The parsed data
+
+`data` is read, never written. The rectangles the chart draws are the *parsed* data, one
+node per rectangle - a grouped treemap has more rectangles than you supplied rows.
+
+| To read a node | Use |
+| ---- | ---- |
+| in a scriptable option | `ctx.raw` (also `ctx.parsed`) |
+| in a tooltip callback | `item.parsed` |
+| anywhere else | `chart.getDatasetMeta(i).controller.getParsed(index)` |
+
+A node carries the raw value `v`, the summed keys `vs`, the group `g` and its level `l`,
+the original row or group record in `_data`, and its geometry.
+
+Editing `data` in place is picked up by the next `chart.update()`; there is no version
+stamp to bump.
+
+#### Plugins that read `dataset.data`
+
+A plugin that walks `dataset.data` alongside `chart.getDatasetMeta(i).data` will see
+different lengths whenever the chart has groups. The datalabels plugin is the common case:
+its formatter receives `dataset.data[index]` as the value, so read the node through the
+controller instead.
+
+```js
+formatter: (_value, ctx) =>
+  ctx.chart.getDatasetMeta(ctx.datasetIndex).controller.getParsed(ctx.dataIndex).v,
+```
+
 ### TypeScript
 
-The controller builds `data` from `tree` at runtime, so JavaScript configurations do not need to
-provide it. Chart.js's TypeScript definitions require the `data` property on every dataset, however.
-TypeScript configurations should provide an empty array to satisfy that requirement:
+A nested object needs the data type spelled out, either through the chart's generic or by
+flattening it up front with the exported `flattenTree`:
 
 ```ts
-const dataset = {
-  data: [],
-  tree: [15, 6, 6, 5, 4, 3, 2, 2],
-};
-```
+new Chart<'treemap', MyRow[]>(ctx, { data: { datasets: [{ data: myTree }] } })
 
-The controller replaces the empty array with the generated treemap data.
-
-```js
-function colorFromRaw(ctx) {
-  if (ctx.type !== 'data') {
-    return 'transparent';
-  }
-  const value = ctx.raw.v;
-  let alpha = (1 + Math.log(value)) / 5;
-  const color = 'green';
-  return helpers.color(color)
-    .alpha(alpha)
-    .rgbString();
-}
-
-const data = [
-  {category: 'main', value: 1},
-  {category: 'main', value: 2},
-  {category: 'main', value: 3},
-  {category: 'other', value: 4},
-  {category: 'other', value: 5},
-];
-
-const config = {
-  type: 'treemap',
-  data: {
-    datasets: [{
-      tree: data,
-      key: 'value',
-      groups: ['category'],
-      backgroundColor: (ctx) => colorFromRaw(ctx),
-    }]
-  },
-};
-```
-
-### Styling
-
-The style of the treemap element can be controlled with the following properties:
-
-| Name | Description
-| ---- | ----
-| `backgroundColor` | The treemap element background color.
-| `borderColor` | The treemap element border color.
-| [`borderRadius`](#borderradius) | Radius of the rectangle of treemap element (in pixels).
-| `borderWidth` | The treemap element border width (in pixels).
-| `spacing` | Fixed distance (in pixels) between all treemap elements.
-| [`displayMode`](#displaymode) | How to display the treemap parent groups.
-
-If the value is `undefined`, fallbacks to the associated `elements.treemap.*` options.
-
-#### borderRadius
-
-If this value is a number, it is applied to all corners of the rectangle (topLeft, topRight, bottomLeft, bottomRight). If this value is an object, the `topLeft` property defines the top-left corners border radius. Similarly, the `topRight`, `bottomLeft`, and `bottomRight` properties can also be specified. Omitted corners have radius of 0.
-
-#### displayMode
-
-This property supports two values:
-
-* `'containerBoxes'` (default): The parent group is represented as a large rectangle, with its child elements displayed inside it.
-* `'headerBoxes'`: The parent group appears as a header, with its child elements positioned below it.
-
-### Interactions
-
-The interaction with each element can be controlled with the following properties:
-
-| Name | Description
-| ---- | -----------
-| `hoverBackgroundColor` | The treemap element background color when hovered.
-| `hoverBorderColor` | The treemap element border color when hovered.
-| `hoverBorderWidth` | The treemap element border width (in pixels) when hovered.
-
-If the value is `undefined`, fallbacks to the associated `elements.treemap.*` options.
-
-## Labels
-
-Namespaces:
-
-* `data.datasets[index].labels` - options for this dataset only
-* `options.datasets.treemap.labels` - options for all treemap datasets
-* `options.elements.treemap.labels` - options for all treemap elements
-* `options` - options for the whole chart
-
-The labels options can control if and how a label, to represent the data, can be shown in the rectangle, with the following properties:
-
-| Name | Type | [Scriptable](https://www.chartjs.org/docs/latest/general/options.html#scriptable-options) | Default
-| ---- | ---- | :----: | ----
-| [`align`](#align) | `string` | Yes | `center`
-| [`color`](#fonts-and-colors) | `Color` \| `Color[]` | Yes | `'black'`
-| `display` | `boolean` | - | `false`
-| [`formatter`](#formatter) | `function` | Yes |
-| [`font`](#fonts-and-colors) | `Font` \| `Font[]` | Yes | `{}`
-| [`hoverColor`](#fonts-and-colors) | `Color` \| `Color[]` | Yes | `undefined`
-| [`hoverFont`](#fonts-and-colors) | `Font` \| `Font[]` | Yes | `{}`
-| [`overflow`](#overflow) | `string` | Yes | `cut`
-| `padding` | `number` | - | `3`
-| [`position`](#position) | `string` | Yes | `middle`
-
-All these values, if `undefined`, fallback to the scopes described in [option resolution](https://www.chartjs.org/docs/latest/general/options.html).
-
-:::warning
-
-Labels only apply if `display` is `true`.
-
-:::
-
-### Align
-
-The align property specifies the text horizontal alignment used when drawing the label. The possible values are:
-
-* `center`: the text is centered. It is the default.
-* `left`: the text is left-aligned.
-* `right`: the text is right-aligned.
-
-### Overflow
-
-The overflow property controls what happens to a label that is too big to fit into a rectangle. The possible values are:
-
-* `cut`: if the label is too big, it will be cut to stay inside the rectangle. It is the default.
-* `hidden`:  the label is removed altogether if the rectangle is too small for it.
-* `fit`:  the label will be automatically fit inside the rectangle if its dimension is bigger than the rectangle size.
-
-### Position
-
-The position property specifies the text vertical alignment used when drawing the label. The possible values are:
-
-* `middle`: the text is in the middle of the rectangle. It is the default.
-* `top`: the text is in the top of the rectangle.
-* `bottom`: the text is in the bottom of the rectangle.
-
-### Formatter
-
-Data values are converted to string. If values are grouped, the value of the group and the value (as string) are shown.
-
-This default behavior can be overridden by the `formatter` which is a [scriptable](https://www.chartjs.org/docs/latest/general/options.html#scriptable-options) option.
-
-A `formatter` can return a string (for a single line) or an array of strings (for multiple lines, where each item represents a new line).
-
-In the following example, every label of the treemap would be displayed with the unit.
-
-```js
-const config = {
-  type: 'treemap',
-  data: {
-    datasets: [{
-      tree: [15, 6, 6, 5, 4, 3, 2, 2],
-      labels: {
-        display: false,
-        formatter: (ctx) => 'Kmq ' + ctx.raw.v
-      }
-    }]
-  },
-};
-```
-
-### Fonts and colors
-
-When the label to draw has multiple lines, you can use different font and color for each row of the label. This is enabled configuring an array of fonts or colors for those options. When the lines are more than the configured fonts of colors, the last configuration of those options is used for all remaining lines.
-
-See on Chart.js documentation more details about [`font`](https://www.chartjs.org/docs/latest/general/fonts.html) and [`color`](https://www.chartjs.org/docs/latest/general/colors.html) options.
-
-## Captions
-
-Namespaces:
-
-* `data.datasets[index].captions` - options for this dataset only
-* `options.datasets.treemap.captions` - options for all treemap datasets
-* `options.elements.treemap.captions` - options for all treemap elements
-* `options` - options for the whole chart
-
-The captions options can control if and how a captions, to represent the group of the chart, can be shown in the rectangle, with the following properties:
-
-| Name | Type | [Scriptable](https://www.chartjs.org/docs/latest/general/options.html#scriptable-options) | Default
-| ---- | ---- | :----: | ----
-| [`align`](#caption-align) | `string` | Yes | `undefined` but `left` is used because default `rtl` option is `false`.
-| `color` | [`Color`](https://www.chartjs.org/docs/latest/general/colors.html) | Yes | `'black'`
-| `display` | `boolean` | - | `true`
-| [`font`](https://www.chartjs.org/docs/latest/general/fonts.html) | `Font` | Yes | `{}`
-| [`formatter`](#caption-formatter) | `function` | Yes |
-| `hoverColor` | [`Color`](https://www.chartjs.org/docs/latest/general/colors.html) | Yes | `undefined`
-| [`hoverFont`](https://www.chartjs.org/docs/latest/general/fonts.html) | `Font` | Yes | `{}`
-| `padding` | `number` | - | `3`
-
-All these values, if `undefined`, fallback to the scopes described in [option resolution](https://www.chartjs.org/docs/latest/general/options.html).
-
-### Caption Align
-
-The align property specifies the text horizontal alignment used when drawing the caption. The possible values are:
-
-* `left`: the text is left-aligned.
-* `center`: the text is centered.
-* `right`: the text is right-aligned.
-
-If `undefined`, `right` is used if `rtl` option is set to `true`, otherwise `left`.
-
-### Caption Formatter
-
-If values are grouped, the value of the group is shown in the chart as caption for all elements belonging to the group.
-
-This default behavior can be overridden by the `formatter` which is a [scriptable](https://www.chartjs.org/docs/latest/general/options.html#scriptable-options) option.
-
-A `formatter` can return a string.
-
-In the following example, every caption of the treemap would be displayed with an additional label.
-
-```js
-const data = [
-  {category: 'main', subcategory: 'one', value: 1},
-  {category: 'main', subcategory: 'one', value: 5},
-  {category: 'main', subcategory: 'one', value: 3},
-  {category: 'main', subcategory: 'two', value: 2},
-  {category: 'main', subcategory: 'two', value: 1},
-  {category: 'main', subcategory: 'two', value: 8},
-  {category: 'other', subcategory: 'one', value: 4},
-  {category: 'other', subcategory: 'one', value: 5},
-  {category: 'other', subcategory: 'two', value: 4},
-  {category: 'other', subcategory: 'two', value: 1},
-];
-const config = {
-  type: 'treemap',
-  data: {
-    datasets: [{
-      tree: data,
-      key: 'value',
-      groups: ['category', 'subcategory', 'value'],
-      captions: {
-        display: true,
-        formatter(ctx) {
-          return ctx.type === 'data' ? 'G: ' + ctx.raw.g : '';
-        }
-      },
-    }]
-  },
-};
+// or
+import { flattenTree } from 'chartjs-chart-treemap'
+const data = flattenTree<MyRow>(myTree, ['value'], 'name')
 ```

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -1,11 +1,11 @@
-import type { LayoutOptions } from './layout'
+import type { LayoutNode, LayoutOptions } from './layout'
 
 import { Chart, DatasetController, registry } from 'chart.js'
 import { clipArea, unclipArea, valueOrDefault } from 'chart.js/helpers'
 
 import { version } from '../package.json'
-import { arrayNotEqual, rectNotEqual, scaleRect } from './helpers/index'
-import { buildData } from './layout'
+import { rectNotEqual, scaleRect } from './helpers/index'
+import { buildNodes, flattenNodes, layoutNodes } from './layout'
 import { layoutDefaults } from './options'
 import { requireVersion } from './utils'
 
@@ -33,21 +33,25 @@ export default class TreemapController extends DatasetController {
   declare static readonly afterRegister: () => void
   declare static readonly afterUnregister: () => void
 
+  // Chart.js assigns this on the class when the controller is registered; its
+  // type definitions do not describe it.
+  declare dataElementType: new () => any
+
   options: any
-  _groups: any[] | undefined
-  _keys: any[] | undefined
   _rect: any
   _rectChanged: boolean
-  _prevTree: any
-  _prevTreeVersion: unknown
+  _nodes: LayoutNode[]
+  _layoutDirty: boolean
+  _fingerprint: string | undefined
 
   constructor(chart: any, datasetIndex: number) {
     super(chart, datasetIndex)
 
-    this._groups = undefined
-    this._keys = undefined
     this._rect = undefined
     this._rectChanged = true
+    this._nodes = []
+    this._layoutDirty = true
+    this._fingerprint = undefined
   }
 
   override initialize() {
@@ -116,39 +120,90 @@ export default class TreemapController extends DatasetController {
     }
   }
 
-  override update(mode: any) {
+  /**
+   * Chart.js calls this before `configure()`, so the chart area is not
+   * available here - see the hierarchy pass in `./layout`, which does not need
+   * one. Elements are created from the parsed nodes rather than from
+   * `dataset.data`, because a treemap with groups has more rectangles than the
+   * user supplied rows.
+   */
+  override buildOrUpdateElements(_resetNewElements?: boolean) {
+    this.parse(0, 0)
+
+    const meta = this.getMeta() as any
+    const count = (meta._parsed as unknown[]).length
+    const elements = meta.data as unknown[]
+    if (elements.length > count) {
+      elements.splice(count, elements.length - count)
+    }
+    while (elements.length < count) {
+      elements.push(new this.dataElementType())
+    }
+  }
+
+  override parse(_start: number, _count: number) {
     const dataset = this.getDataset() as any
-    const { data } = this.getMeta()
+    if (dataset.tree !== undefined) {
+      throw new Error(
+        'chartjs-chart-treemap v5: the "tree" option was renamed to "data". ' +
+          'See https://chartjs-chart-treemap.pages.dev/usage/'
+      )
+    }
+
     const options = this.options
-    const groups = options.groups || []
     const keys = [options.key || ''].concat(options.sumKeys || [])
-    dataset.tree = dataset.tree || dataset.data || []
-    const tree = dataset.tree
-    const treeVersion = dataset.treeVersion
+    const nodes = buildNodes(dataset.data || [], keys, this._layoutOptions())
+    const flat = flattenNodes(nodes)
+
+    // A `chart.update('none')` per wheel event must not re-run the layout when
+    // nothing about the data changed, so keep the previous nodes - and with
+    // them their geometry - when the hierarchy is identical.
+    const fingerprint = flat.map((node) => `${node.v}\u0000${node.g}\u0000${node.l}`).join('\u0001')
+    if (this._fingerprint === fingerprint) {
+      return
+    }
+
+    this._fingerprint = fingerprint
+    this._nodes = nodes
+    ;(this.getMeta() as any)._parsed = flat
+    this._layoutDirty = true
+  }
+
+  // `getContext` exists on DatasetController at runtime but not in its type
+  // definitions, so this cannot be declared as an override.
+  getContext(index: number, active?: boolean, mode?: string) {
+    const base = (DatasetController.prototype as any).getContext
+    const context = base.call(this, index, active, mode)
+    const parsed = typeof index === 'number' ? this.getParsed(index) : undefined
+    if (parsed) {
+      context.raw = parsed
+      context.parsed = parsed
+    }
+    return context
+  }
+
+  override getLabelAndValue(index: number) {
+    const node = this.getParsed(index) as any
+    if (!node) {
+      return { label: '', value: '' }
+    }
+    const dataset = this.getDataset() as any
+    const label = node.g ?? node._data?.label ?? dataset.label
+    return { label: label === undefined ? '' : `${label}`, value: `${node.v}` }
+  }
+
+  override update(mode: any) {
+    const { data } = this.getMeta()
 
     if (mode === 'reset') {
       // reset is called before 2nd configure and is only called if animations are enabled. So wen need an extra configure call here.
       this.configure()
     }
 
-    if (
-      this._rectChanged ||
-      arrayNotEqual(this._keys || [], keys) ||
-      arrayNotEqual(this._groups || [], groups) ||
-      this._prevTree !== tree ||
-      this._prevTreeVersion !== treeVersion
-    ) {
-      this._groups = groups.slice()
-      this._keys = keys.slice()
-      this._prevTree = tree
-      this._prevTreeVersion = treeVersion
+    if (this._layoutDirty || this._rectChanged) {
+      layoutNodes(this._nodes, this._rect, this._layoutOptions())
+      this._layoutDirty = false
       this._rectChanged = false
-
-      dataset.data = buildData(tree, this._keys, this._rect, this._layoutOptions())
-      // @ts-expect-error using private stuff
-      this._dataCheck()
-      // @ts-expect-error using private stuff
-      this._resyncElements()
     }
 
     this.updateElements(data, 0, data.length, mode)
@@ -156,7 +211,6 @@ export default class TreemapController extends DatasetController {
 
   override updateElements(rects: any[], start: number, count: number, mode: any) {
     const reset = mode === 'reset'
-    const dataset = this.getDataset() as any
     const firstOpts = this.resolveDataElementOptions(start, mode)
     this._rect.options = firstOpts
     const sharedOptions = this.getSharedOptions(firstOpts)
@@ -166,7 +220,9 @@ export default class TreemapController extends DatasetController {
 
     for (let i = start; i < start + count; i++) {
       const options = sharedOptions || this.resolveDataElementOptions(i, mode)
-      const properties: any = scaleRect(dataset.data[i], xScale, yScale, spacing)
+      const node = this.getParsed(i) as any
+      const properties: any = scaleRect(node, xScale, yScale, spacing)
+      properties.hidden = properties.hidden || !!node.hidden
       if (reset) {
         properties.width = 0
         properties.height = 0
@@ -184,8 +240,6 @@ export default class TreemapController extends DatasetController {
   override draw() {
     const { ctx, chartArea } = this.chart
     const metadata = ((this.getMeta() as any).data || []) as any[]
-    const dataset = this.getDataset() as any
-    const data = dataset.data
     const { displayMode, rtl, spacing } = this.options
     const layout = { displayMode, rtl, spacing }
 
@@ -193,7 +247,7 @@ export default class TreemapController extends DatasetController {
     for (let i = 0, ilen = metadata.length; i < ilen; ++i) {
       const rect = metadata[i]
       if (!rect.hidden) {
-        rect.draw(ctx, data[i], layout)
+        rect.draw(ctx, this.getParsed(i) as any, layout)
       }
     }
     unclipArea(ctx)
@@ -247,10 +301,9 @@ export default class TreemapController extends DatasetController {
     tooltip: {
       callbacks: {
         label(item: any) {
-          const dataset = item.dataset
-          const dataItem = dataset.data[item.dataIndex]
-          const label = dataItem.g || dataItem._data.label || dataset.label
-          return (label ? `${label}: ` : '') + dataItem.v
+          const node = item.parsed
+          const label = node.g || node._data?.label || item.dataset.label
+          return (label ? `${label}: ` : '') + node.v
         },
         title(items: any[]) {
           if (items.length) {

--- a/src/index.esm.ts
+++ b/src/index.esm.ts
@@ -11,3 +11,4 @@ export type {
 
 export { default as TreemapController } from './controller'
 export { default as TreemapElement } from './element'
+export { flattenTree } from './utils'

--- a/src/layout.ts
+++ b/src/layout.ts
@@ -61,7 +61,13 @@ function buildHierarchy(
       gidx < glen - 1 && nextGroupIndex < glen
         ? buildHierarchy(record.children, nextGroupIndex, keys, layout, node.g)
         : []
-    node._children = children
+    // Non-enumerable: the geometry pass needs it on every layout, but it
+    // must not show up in ctx.raw.
+    Object.defineProperty(node, '_children', {
+      configurable: true,
+      value: children,
+      writable: true,
+    })
     node.isLeaf = !children.length
   }
   return nodes
@@ -84,12 +90,7 @@ export function flattenNodes(nodes: LayoutNode[]): LayoutNode[] {
  * Packs each set of siblings into its parent's rectangle, writing the
  * coordinates onto the nodes the first pass produced.
  */
-export function layoutNodes(
-  nodes: LayoutNode[],
-  rect: any,
-  layout: LayoutOptions,
-  parentSum?: number
-) {
+function layoutLevel(nodes: LayoutNode[], rect: any, layout: LayoutOptions, parentSum?: number) {
   if (parentSum !== undefined) {
     for (const node of nodes) {
       node.gs = parentSum
@@ -99,9 +100,15 @@ export function layoutNodes(
 
   for (const node of nodes) {
     if (node._children?.length) {
-      layoutNodes(node._children, getSubRect(node, rect, layout), layout, node.s)
+      layoutLevel(node._children, getSubRect(node, rect, layout), layout, node.s)
     }
   }
+}
+
+/** Writes the geometry for a whole tree of nodes, then applies headerBoxes. */
+export function layoutNodes(nodes: LayoutNode[], rect: any, layout: LayoutOptions) {
+  layoutLevel(nodes, rect, layout)
+  applyHeaderBoxes(flattenNodes(nodes), layout)
 }
 
 /** The rectangle left for a group's children once its border and caption are taken. */
@@ -151,6 +158,32 @@ export function buildNodes(tree: any, keys: string[], layout: LayoutOptions): La
   return nodes
 }
 
+/**
+ * In headerBoxes mode a group is drawn as a header strip rather than a box
+ * around its children, and a group whose caption does not fit is not drawn at
+ * all. It is marked hidden rather than removed: the number of parsed nodes must
+ * not depend on the size of the chart area.
+ */
+function applyHeaderBoxes(nodes: LayoutNode[], layout: LayoutOptions) {
+  const { captions, displayMode } = layout
+  if (displayMode !== 'headerBoxes') {
+    return
+  }
+  const font = toFont(captions.font)
+  const padding = valueOrDefault(captions.padding, 3)
+  for (const node of nodes) {
+    if (node.isLeaf) {
+      continue
+    }
+    if (shouldDrawCaption(displayMode, node, captions)) {
+      node.h = getCaptionHeight(displayMode, node, font, padding)
+      node.hidden = false
+    } else {
+      node.hidden = true
+    }
+  }
+}
+
 /** Turns the user's input into the flat list of rectangles the chart draws. */
 export function buildData(
   tree: any,
@@ -158,24 +191,7 @@ export function buildData(
   mainRect: DrawRect,
   layout: LayoutOptions
 ): TreemapDataPoint[] {
-  const { captions, displayMode } = layout
   const nodes = buildNodes(tree, keys, layout)
   layoutNodes(nodes, mainRect, layout)
-
-  const font = toFont(captions.font)
-  const padding = valueOrDefault(captions.padding, 3)
   return flattenNodes(nodes)
-    .map((d) => {
-      // The nested link is internal; it must not reach ctx.raw.
-      delete d._children
-      if (displayMode !== 'headerBoxes' || d.isLeaf) {
-        return d
-      }
-      if (!shouldDrawCaption(displayMode, d, captions)) {
-        return undefined
-      }
-      const captionHeight = getCaptionHeight(displayMode, d, font, padding)
-      return { ...d, h: captionHeight }
-    })
-    .filter(Boolean) as TreemapDataPoint[]
 }

--- a/src/text.ts
+++ b/src/text.ts
@@ -90,11 +90,11 @@ export function drawText(
 ) {
   const { captions, labels } = options
   const { displayMode } = layout
-  ctx.save()
-  ctx.beginPath()
-  ctx.rect(rect.x, rect.y, rect.w, rect.h)
-  ctx.clip()
   const isLeaf = item && (!defined(item.l) || item.isLeaf)
+
+  // Resolve the text before touching the canvas. Most elements in a large
+  // treemap draw no text at all, and clipping is not free: this is the
+  // difference between five canvas calls per element and none.
   let block: TextBlock | undefined
   if (isLeaf) {
     if (labels.display) {
@@ -103,9 +103,15 @@ export function drawText(
   } else if (shouldDrawCaption(displayMode, rect, captions)) {
     block = captionBlock(ctx, rect, options, item, element, layout)
   }
-  if (block) {
-    drawTextBlock(ctx, rect, block)
+  if (!block) {
+    return
   }
+
+  ctx.save()
+  ctx.beginPath()
+  ctx.rect(rect.x, rect.y, rect.w, rect.h)
+  ctx.clip()
+  drawTextBlock(ctx, rect, block)
   ctx.restore()
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -103,12 +103,14 @@ export interface TreemapControllerDatasetOptions<DType> {
   labels?: TreemapControllerDatasetLabelsOptions
   label?: string
 
-  data: TreemapDataPoint[]
+  /**
+   * Numbers, objects, or a nested object addressed through `leafKey`.
+   * The array is read, never written: the layout nodes live in the parsed data.
+   */
+  data: number[] | DType[] | AnyObject
   groups?: Array<keyof DType>
   sumKeys?: Array<keyof DType>
-  tree: number[] | DType[] | AnyObject
   leafKey?: keyof DType
-  treeVersion?: number | string
   key?: keyof DType
 }
 
@@ -125,6 +127,8 @@ export interface TreemapDataPoint {
   vs?: AnyObject
   _data?: AnyObject
   isLeaf?: boolean
+  /** headerBoxes: the group's caption does not fit, so nothing is drawn. */
+  hidden?: boolean
 }
 
 declare module 'chart.js' {
@@ -132,9 +136,9 @@ declare module 'chart.js' {
     treemap: {
       chartOptions: CoreChartOptions<'treemap'>
       datasetOptions: TreemapControllerDatasetOptions<Record<string, unknown>>
-      defaultDataPoint: TreemapDataPoint
+      defaultDataPoint: number | AnyObject
       metaExtensions: AnyObject
-      parsedDataType: unknown
+      parsedDataType: TreemapDataPoint
       scales: never
     }
   }

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,4 +1,13 @@
-import { flatten, group, index, normalizeTreeToArray, requireVersion, sort, sum } from './utils'
+import {
+  flatten,
+  flattenTree,
+  group,
+  index,
+  normalizeTreeToArray,
+  requireVersion,
+  sort,
+  sum,
+} from './utils'
 
 describe('utils', () => {
   describe('flatten', () => {
@@ -196,6 +205,16 @@ describe('utils', () => {
       ]
       expect(sum(a, 'x')).toEqual(16)
       expect(sum(a, 'y')).toEqual(6)
+    })
+  })
+
+  describe('flattenTree', () => {
+    it('flattens a nested object into the array form of data', () => {
+      const tree = { a: { one: 1, two: 2 }, b: { three: 3 } }
+
+      expect(flattenTree(tree, ['value'], 'name')).toEqual(
+        normalizeTreeToArray(['value'], 'name', tree)
+      )
     })
   })
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,5 @@
+import type { AnyObject } from './types'
+
 import { isObject } from 'chart.js/helpers'
 
 const isOlderPart = (act: string, req: string) =>
@@ -39,6 +41,17 @@ function scanTreeObject(
   }
   tree.splice(objIndex, 1)
   return result
+}
+
+/**
+ * Flattens a nested object into the array form of `data`.
+ *
+ * The controller does this at runtime, so JavaScript configurations never need
+ * it. TypeScript users who would rather pass an array than a generic can call
+ * it up front.
+ */
+export function flattenTree<T = AnyObject>(tree: AnyObject, keys: string[], leafKey: string): T[] {
+  return normalizeTreeToArray(keys, leafKey, tree) as T[]
 }
 
 export function normalizeTreeToArray(keys: string[], leafKey: string, obj: Record<string, any>) {

--- a/test/fixtures/advanced/zoom.js
+++ b/test/fixtures/advanced/zoom.js
@@ -3,7 +3,7 @@ export default {
     type: 'treemap',
     data: {
       datasets: [{
-        tree: [6, 6, 4, 3, 2, 2, 1],
+        data: [6, 6, 4, 3, 2, 2, 1],
         backgroundColor: 'green',
         borderColor: 'black',
         borderWidth: 8

--- a/test/fixtures/basic/update-tree.js
+++ b/test/fixtures/basic/update-tree.js
@@ -3,7 +3,7 @@ export default {
     type: 'treemap',
     data: {
       datasets: [{
-        tree: [6, 6, 4, 3, 2, 2, 1],
+        data: [6, 6, 4, 3, 2, 2, 1],
         backgroundColor: 'red',
         borderWidth: 10,
         borderColor: 'black'
@@ -19,7 +19,7 @@ export default {
       width: 512
     },
     run(chart) {
-      chart.data.datasets[0].tree = [1, 2, 3, 4];
+      chart.data.datasets[0].data = [1, 2, 3, 4];
       chart.update();
     }
   }

--- a/test/fixtures/basic/update.js
+++ b/test/fixtures/basic/update.js
@@ -3,7 +3,7 @@ export default {
     type: 'treemap',
     data: {
       datasets: [{
-        tree: [6, 6, 4, 3, 2, 2, 1],
+        data: [6, 6, 4, 3, 2, 2, 1],
         backgroundColor: 'red',
         borderWidth: 10,
         borderColor: 'black'
@@ -19,7 +19,7 @@ export default {
       width: 512
     },
     run(chart) {
-      chart.data.datasets[0].tree = [1, 2, 3];
+      chart.data.datasets[0].data = [1, 2, 3];
       chart.update();
     }
   }

--- a/test/fixtures/events/hoverCaptions.js
+++ b/test/fixtures/events/hoverCaptions.js
@@ -18,7 +18,7 @@ export default {
     data: {
       datasets: [{
         label: 'Simple treemap',
-        tree: data,
+        data: data,
         key: 'value',
         groups: ['category', 'subcategory', 'value'],
         backgroundColor: 'red',

--- a/test/fixtures/grouped/basic-large.js
+++ b/test/fixtures/grouped/basic-large.js
@@ -1,7 +1,7 @@
 const arrayN = (n) => Array.from({length: n}).map((_, i) => i);
 
 const groups = arrayN(10);
-const tree = groups.reduce((acc, grp) => [
+const data = groups.reduce((acc, grp) => [
   ...acc,
   ...arrayN(grp * 10).map(i => ({grp: `group: ${grp}`, sub: `sub: ${i}`, value: (i % 10) * 10}))
 ], []);
@@ -11,7 +11,7 @@ export default {
     type: 'treemap',
     data: {
       datasets: [{
-        tree,
+        data,
         backgroundColor: (ctx) => ctx.raw.l ? 'dimgray' : 'silver',
         borderColor: (ctx) => ctx.raw.l ? 'white' : 'black',
         borderWidth: 1,

--- a/test/fixtures/grouped/basic-rtl.js
+++ b/test/fixtures/grouped/basic-rtl.js
@@ -11,7 +11,7 @@ export default {
     type: 'treemap',
     data: {
       datasets: [{
-        tree: data,
+        data: data,
         key: 'value',
         groups: ['category', 'subcategory'],
         rtl: true,

--- a/test/fixtures/grouped/basic.js
+++ b/test/fixtures/grouped/basic.js
@@ -11,7 +11,7 @@ export default {
     type: 'treemap',
     data: {
       datasets: [{
-        tree: data,
+        data: data,
         key: 'value',
         groups: ['category'],
         captions: {

--- a/test/fixtures/grouped/border.js
+++ b/test/fixtures/grouped/border.js
@@ -11,7 +11,7 @@ export default {
     type: 'treemap',
     data: {
       datasets: [{
-        tree: data,
+        data: data,
         key: 'value',
         groups: ['category'],
         borderWidth: {top: 10, left: 5, right: 15, bottom: 20},

--- a/test/fixtures/grouped/borderWidthAsObject.js
+++ b/test/fixtures/grouped/borderWidthAsObject.js
@@ -1,4 +1,4 @@
-const tree = [
+const data = [
   {
     p1: '/etc',
     p2: 'passwd',
@@ -16,7 +16,7 @@ export default {
     type: 'treemap',
     data: {
       datasets: [{
-        tree,
+        data,
         groups: ['p1', 'p2'],
         key: 'value',
         borderColor: 'black',

--- a/test/fixtures/grouped/captionsAlign.js
+++ b/test/fixtures/grouped/captionsAlign.js
@@ -17,7 +17,7 @@ export default {
     type: 'treemap',
     data: {
       datasets: [{
-        tree: data,
+        data: data,
         key: 'value',
         groups: ['category', 'subcategory', 'value'],
         backgroundColor: 'lightGreen',

--- a/test/fixtures/grouped/captionsFont.js
+++ b/test/fixtures/grouped/captionsFont.js
@@ -17,7 +17,7 @@ export default {
     type: 'treemap',
     data: {
       datasets: [{
-        tree: data,
+        data: data,
         key: 'value',
         groups: ['category', 'subcategory', 'value'],
         backgroundColor: 'lightGreen',

--- a/test/fixtures/grouped/captionsFormatter.js
+++ b/test/fixtures/grouped/captionsFormatter.js
@@ -17,7 +17,7 @@ export default {
     type: 'treemap',
     data: {
       datasets: [{
-        tree: data,
+        data: data,
         key: 'value',
         groups: ['category', 'subcategory', 'value'],
         backgroundColor: 'lightGreen',

--- a/test/fixtures/grouped/captionsPadding.js
+++ b/test/fixtures/grouped/captionsPadding.js
@@ -17,7 +17,7 @@ export default {
     type: 'treemap',
     data: {
       datasets: [{
-        tree: data,
+        data: data,
         key: 'value',
         groups: ['category', 'subcategory', 'value'],
         backgroundColor: 'lightGreen',

--- a/test/fixtures/grouped/captionsTruncating.js
+++ b/test/fixtures/grouped/captionsTruncating.js
@@ -22,7 +22,7 @@ export default {
     type: 'treemap',
     data: {
       datasets: [{
-        tree: data,
+        data: data,
         key: 'value',
         groups: ['category', 'subcategory', 'value'],
         backgroundColor: 'lightGreen',

--- a/test/fixtures/grouped/captionsWithoutDisplay.js
+++ b/test/fixtures/grouped/captionsWithoutDisplay.js
@@ -17,7 +17,7 @@ export default {
     type: 'treemap',
     data: {
       datasets: [{
-        tree: data,
+        data: data,
         key: 'value',
         groups: ['category', 'subcategory', 'value'],
         backgroundColor: 'lightGreen',

--- a/test/fixtures/grouped/missingGroups.js
+++ b/test/fixtures/grouped/missingGroups.js
@@ -15,7 +15,7 @@ export default {
     data: {
       datasets: [
         {
-          tree: data,
+          data: data,
           key: 'value',
           groups: ['folder', 'component', 'subFolder', 'file'],
           spacing: 2,

--- a/test/fixtures/grouped/sumKeys.js
+++ b/test/fixtures/grouped/sumKeys.js
@@ -11,7 +11,7 @@ export default {
     type: 'treemap',
     data: {
       datasets: [{
-        tree: data,
+        data: data,
         key: 'value',
         groups: ['category'],
         sumKeys: ['another'],

--- a/test/fixtures/grouped/treeBasic.js
+++ b/test/fixtures/grouped/treeBasic.js
@@ -33,7 +33,7 @@ export default {
     type: 'treemap',
     data: {
       datasets: [{
-        tree: data,
+        data: data,
         key: 'value',
         groups: ['0', '1', '2', '_leaf'],
         captions: {

--- a/test/fixtures/grouped/treeBasicAndCaptions.js
+++ b/test/fixtures/grouped/treeBasicAndCaptions.js
@@ -32,7 +32,7 @@ export default {
     type: 'treemap',
     data: {
       datasets: [{
-        tree: data,
+        data: data,
         key: 'value',
         groups: ['0', '1', '2', '_leaf'],
         captions: {

--- a/test/fixtures/grouped/treeBasicWithGroupsNumbers.js
+++ b/test/fixtures/grouped/treeBasicWithGroupsNumbers.js
@@ -32,7 +32,7 @@ export default {
     type: 'treemap',
     data: {
       datasets: [{
-        tree: data,
+        data: data,
         key: 'value',
         groups: [0, 1, 2, '_leaf'],
         captions: {

--- a/test/fixtures/grouped/treeBasicWithLeafKey.js
+++ b/test/fixtures/grouped/treeBasicWithLeafKey.js
@@ -33,7 +33,7 @@ export default {
     type: 'treemap',
     data: {
       datasets: [{
-        tree: data,
+        data: data,
         leafKey: '_test',
         key: 'value',
         groups: ['0', '1', '2', '_test'],

--- a/test/fixtures/grouped/treeSumKeys.js
+++ b/test/fixtures/grouped/treeSumKeys.js
@@ -38,7 +38,7 @@ export default {
     type: 'treemap',
     data: {
       datasets: [{
-        tree: data,
+        data: data,
         key: 'value',
         sumKeys: ['another'],
         groups: ['0', '1', '2', '_leaf'],

--- a/test/fixtures/grouped/treeUngrouped.js
+++ b/test/fixtures/grouped/treeUngrouped.js
@@ -32,7 +32,7 @@ export default {
     type: 'treemap',
     data: {
       datasets: [{
-        tree: data,
+        data: data,
         key: 'value',
         captions: {
           display: false

--- a/test/fixtures/grouped/variableDepth.js
+++ b/test/fixtures/grouped/variableDepth.js
@@ -11,7 +11,7 @@ export default {
     type: 'treemap',
     data: {
       datasets: [{
-        tree: data,
+        data: data,
         key: 'value',
         groups: ['year', 'quarter', 'month'],
         spacing: 2,

--- a/test/fixtures/headersbox/grouped-large.js
+++ b/test/fixtures/headersbox/grouped-large.js
@@ -1,7 +1,7 @@
 const arrayN = (n) => Array.from({length: n}).map((_, i) => i);
 
 const groups = arrayN(10);
-const tree = groups.reduce((acc, grp) => [
+const data = groups.reduce((acc, grp) => [
   ...acc,
   ...arrayN(grp * 10).map(i => ({grp: `group: ${grp}`, sub: `sub: ${i}`, value: (i % 10) * 10}))
 ], []);
@@ -11,7 +11,7 @@ export default {
     type: 'treemap',
     data: {
       datasets: [{
-        tree,
+        data,
         backgroundColor: (ctx) => ctx.raw.l ? 'dimgray' : 'silver',
         borderColor: (ctx) => ctx.raw.l ? 'white' : 'black',
         borderWidth: 0,

--- a/test/fixtures/headersbox/grouped.js
+++ b/test/fixtures/headersbox/grouped.js
@@ -1,7 +1,7 @@
 const arrayN = (n) => Array.from({length: n}).map((_, i) => i);
 
 const groups = arrayN(4);
-const tree = groups.reduce((acc, grp) => [
+const data = groups.reduce((acc, grp) => [
   ...acc,
   ...arrayN(grp * 4).map(i => ({grp: `group: ${grp}`, sub: `sub: ${i}`, value: (i % 4) * 4}))
 ], []);
@@ -11,7 +11,7 @@ export default {
     type: 'treemap',
     data: {
       datasets: [{
-        tree,
+        data,
         backgroundColor: (ctx) => ctx.raw.l ? 'lightblue' : 'dimgray',
         borderColor: 'dimgray',
         borderWidth: 1,

--- a/test/fixtures/headersbox/large-captions.js
+++ b/test/fixtures/headersbox/large-captions.js
@@ -1,7 +1,7 @@
 const arrayN = (n) => Array.from({length: n}).map((_, i) => i);
 
 const groups = arrayN(10);
-const tree = groups.reduce((acc, grp) => [
+const data = groups.reduce((acc, grp) => [
   ...acc,
   ...arrayN(grp * 10).map(i => ({grp: `group: ${grp}`, sub: `sub: ${i}`, value: (i % 10) * 10}))
 ], []);
@@ -11,7 +11,7 @@ export default {
     type: 'treemap',
     data: {
       datasets: [{
-        tree,
+        data,
         backgroundColor: (ctx) => ctx.raw.l ? 'dimgray' : 'silver',
         borderColor: (ctx) => ctx.raw.l ? 'white' : 'black',
         borderWidth: 0,

--- a/test/fixtures/headersbox/no-captions.js
+++ b/test/fixtures/headersbox/no-captions.js
@@ -1,7 +1,7 @@
 const arrayN = (n) => Array.from({length: n}).map((_, i) => i);
 
 const groups = arrayN(5);
-const tree = groups.reduce((acc, grp) => [
+const data = groups.reduce((acc, grp) => [
   ...acc,
   ...arrayN(grp * 5).map(i => ({grp: `group: ${grp}`, sub: `sub: ${i}`, value: (i % 5) * 5}))
 ], []);
@@ -13,7 +13,7 @@ export default {
     type: 'treemap',
     data: {
       datasets: [{
-        tree,
+        data,
         backgroundColor: (ctx) => {
           if (ctx.raw.l === 0) {
             return 'dimgray';

--- a/test/fixtures/headersbox/variableDepth.js
+++ b/test/fixtures/headersbox/variableDepth.js
@@ -12,7 +12,7 @@ export default {
     type: 'treemap',
     data: {
       datasets: [{
-        tree: data,
+        data: data,
         key: 'value',
         groups: ['year', 'quarter', 'month'],
         spacing: 2,

--- a/test/fixtures/issues/77.js
+++ b/test/fixtures/issues/77.js
@@ -1,4 +1,4 @@
-const tree = [
+const data = [
   {
     p1: '/etc',
     p2: 'passwd',
@@ -16,7 +16,7 @@ export default {
     type: 'treemap',
     data: {
       datasets: [{
-        tree,
+        data,
         groups: ['p1', 'p2'],
         key: 'value',
         spacing: 20,

--- a/test/integration/browser-module/module.spec.js
+++ b/test/integration/browser-module/module.spec.js
@@ -34,7 +34,7 @@ describe('browser esm integration', () => {
       data: {
         datasets: [
           {
-            tree: [6, 6, 4, 3, 2, 2, 1],
+            data: [6, 6, 4, 3, 2, 2, 1],
           },
         ],
       },
@@ -43,7 +43,7 @@ describe('browser esm integration', () => {
 
     expect(chart.config.type).toBe('treemap')
     expect(chart.data.datasets.length).toBe(1)
-    expect(chart.data.datasets[0].tree.length).toBe(7)
+    expect(chart.data.datasets[0].data.length).toBe(7)
     expect(chart.getDatasetMeta(0).type).toBe('treemap')
     expect(chart.getDatasetMeta(0).controller).toBeTruthy()
 
@@ -57,7 +57,7 @@ describe('browser esm integration', () => {
     canvas = document.createElement('canvas')
     document.body.appendChild(canvas)
     const chart = new Chart(canvas.getContext('2d'), {
-      data: { datasets: [{ tree: [1] }] },
+      data: { datasets: [{ data: [1] }] },
       type: 'treemap',
     })
 

--- a/test/integration/node-commonjs/test.cjs
+++ b/test/integration/node-commonjs/test.cjs
@@ -16,7 +16,7 @@ module.exports = new Chart(ctx, {
   data: {
     datasets: [
       {
-        tree: [6, 6, 4, 3, 2, 2, 1],
+        data: [6, 6, 4, 3, 2, 2, 1],
       },
     ],
   },

--- a/test/integration/node-module/test.mjs
+++ b/test/integration/node-module/test.mjs
@@ -14,7 +14,7 @@ export const chart = new Chart(ctx, {
   data: {
     datasets: [
       {
-        tree: [6, 6, 4, 3, 2, 2, 1],
+        data: [6, 6, 4, 3, 2, 2, 1],
       },
     ],
   },

--- a/test/specs/controller.spec.js
+++ b/test/specs/controller.spec.js
@@ -1,68 +1,99 @@
+/** The layout nodes, which v5 exposes as the parsed data. */
+function nodes(chart) {
+  const meta = chart.getDatasetMeta(0)
+  return meta.data.map((_element, index) => meta.controller.getParsed(index))
+}
+
 describe('controller', () => {
   it('should be registered', () => {
     expect(Chart.registry.controllers.items.treemap).toBeDefined()
   })
 
-  it('should not rebuild data when nothing has changed', () => {
-    const origData = [1, 2, 3]
+  it('never modifies the array the user passed', () => {
+    const data = [1, 2, 3]
     const chart = acquireChart({
-      data: {
-        datasets: [
-          {
-            tree: origData,
-          },
-        ],
-      },
-      type: 'treemap',
-    })
-    const buildData = chart.data.datasets[0].data
-    expect(buildData).not.toBe(origData)
-    chart.update()
-    expect(buildData).toBe(chart.data.datasets[0].data)
-  })
-
-  it('should rebuild data when the tree is mutated in place', () => {
-    const tree = [1, 2]
-    const dataset = { tree, treeVersion: 0 }
-    const chart = acquireChart({
-      data: {
-        datasets: [dataset],
-      },
+      data: { datasets: [{ data }] },
       type: 'treemap',
     })
 
-    expect(chart.data.datasets[0].data.map((item) => item.v)).toEqual([2, 1])
-
-    tree[0] = 9
-    dataset.treeVersion++
+    expect(chart.data.datasets[0].data).toBe(data)
+    expect(data).toEqual([1, 2, 3])
     chart.update()
-
-    expect(chart.data.datasets[0].data.map((item) => item.v)).toEqual([9, 2])
+    expect(chart.data.datasets[0].data).toBe(data)
+    expect(data).toEqual([1, 2, 3])
   })
 
-  it('should rebuild data when a tree item is mutated in place', () => {
-    const tree = [
+  it('keeps the same node objects when nothing has changed', () => {
+    const chart = acquireChart({
+      data: { datasets: [{ data: [1, 2, 3] }] },
+      type: 'treemap',
+    })
+    const before = nodes(chart)
+
+    chart.update()
+
+    expect(nodes(chart)[0]).toBe(before[0])
+    expect(nodes(chart).map((node) => node.v)).toEqual([3, 2, 1])
+  })
+
+  it('picks up an in-place edit without a version stamp', () => {
+    const data = [1, 2]
+    const chart = acquireChart({
+      data: { datasets: [{ data }] },
+      type: 'treemap',
+    })
+
+    expect(nodes(chart).map((node) => node.v)).toEqual([2, 1])
+
+    data[0] = 9
+    chart.update()
+
+    expect(nodes(chart).map((node) => node.v)).toEqual([9, 2])
+  })
+
+  it('picks up an in-place edit of an item without a version stamp', () => {
+    const data = [
       { category: 'a', value: 1 },
       { category: 'b', value: 2 },
     ]
-    const dataset = { groups: ['category'], key: 'value', tree, treeVersion: 'initial' }
     const chart = acquireChart({
-      data: {
-        datasets: [dataset],
-      },
+      data: { datasets: [{ data, groups: ['category'], key: 'value' }] },
       type: 'treemap',
     })
 
-    tree[0].value = 9
-    dataset.treeVersion = 'updated'
+    data[0].value = 9
     chart.update()
 
-    const category = chart.data.datasets[0].data.find((item) => item.g === 'a')
-    expect(category.v).toBe(9)
+    expect(nodes(chart).find((node) => node.g === 'a').v).toBe(9)
+  })
+
+  it('picks up a push without a version stamp', () => {
+    const data = [1, 2]
+    const chart = acquireChart({
+      data: { datasets: [{ data }] },
+      type: 'treemap',
+    })
+
+    expect(chart.getDatasetMeta(0).data.length).toBe(2)
+
+    data.push(5)
+    chart.update()
+
+    expect(chart.getDatasetMeta(0).data.length).toBe(3)
+    expect(nodes(chart).map((node) => node.v)).toEqual([5, 2, 1])
+  })
+
+  it('throws a migration message when the removed tree option is used', () => {
+    expect(() =>
+      acquireChart({
+        data: { datasets: [{ tree: [1, 2, 3] }] },
+        type: 'treemap',
+      })
+    ).toThrowError(/"tree" option was renamed to "data"/)
   })
 
   it('should group 3 levels of data', () => {
-    const tree = [
+    const data = [
       { a: 'a1', b: 'b1', c: 'c1', key: 10 },
       { a: 'a1', b: 'b1', c: 'c1', key: 20 },
       { a: 'a2', b: 'b1', c: 'c1', key: 40 },
@@ -77,15 +108,15 @@ describe('controller', () => {
       data: {
         datasets: [
           {
+            data,
             groups: ['a', 'b', 'c'],
             key: 'key',
-            tree,
           },
         ],
       },
       type: 'treemap',
     })
-    const buildData = chart.data.datasets[0].data
+    const buildData = nodes(chart)
 
     const a1b1 = buildData.find((o) => o._data.path === 'a1.b1')
     expect(a1b1.v).toBe(30)
@@ -125,7 +156,7 @@ describe('controller', () => {
   })
 
   it('should skip missing group levels', () => {
-    const tree = [
+    const data = [
       { component: null, file: 'index.js', folder: './src', key: 1, subFolder: null },
       { component: 'A', file: 'A.js', folder: './src', key: 2, subFolder: null },
       { component: 'A', file: 'B.js', folder: './src', key: 3, subFolder: 'nested' },
@@ -134,15 +165,15 @@ describe('controller', () => {
       data: {
         datasets: [
           {
+            data,
             groups: ['folder', 'component', 'subFolder', 'file'],
             key: 'key',
-            tree,
           },
         ],
       },
       type: 'treemap',
     })
-    const buildData = chart.data.datasets[0].data
+    const buildData = nodes(chart)
 
     const root = buildData.find((o) => o._data.path === './src')
     expect(root.v).toBe(6)
@@ -165,12 +196,13 @@ describe('controller', () => {
     expect(buildData.find((o) => o._data.path === './src.index.js.index.js')).toBeUndefined()
   })
 
-  it('should update labels when tree changes', () => {
+  it('should update labels when data changes', () => {
     const labels = []
     const chart = acquireChart({
       data: {
         datasets: [
           {
+            data: [1],
             labels: {
               display: true,
               formatter: (ctx) => {
@@ -178,7 +210,6 @@ describe('controller', () => {
                 return `${ctx.raw.v}`
               },
             },
-            tree: [1],
           },
         ],
       },
@@ -189,7 +220,7 @@ describe('controller', () => {
     expect(labels).toContain(1)
 
     labels.length = 0
-    chart.data.datasets[0].tree = [5]
+    chart.data.datasets[0].data = [5]
     chart.update()
 
     expect(labels).toContain(5)
@@ -201,6 +232,7 @@ describe('controller', () => {
       data: {
         datasets: [
           {
+            data: [1],
             labels: {
               display: false,
               formatter: (ctx) => {
@@ -208,7 +240,6 @@ describe('controller', () => {
                 return `${ctx.raw.v}`
               },
             },
-            tree: [1],
           },
         ],
       },
@@ -242,15 +273,15 @@ describe('controller', () => {
               display: true,
               formatter: oldFormatter,
             },
+            data: [
+              { division: 'b', region: 'a', state: 'c', value: 1 },
+              { division: 'b', region: 'a', state: 'd', value: 2 },
+            ],
             groups: ['region', 'division', 'state'],
             key: 'value',
             labels: {
               display: false,
             },
-            tree: [
-              { division: 'b', region: 'a', state: 'c', value: 1 },
-              { division: 'b', region: 'a', state: 'd', value: 2 },
-            ],
           },
         ],
       },
@@ -281,11 +312,11 @@ describe('controller', () => {
       data: {
         datasets: [
           {
+            data: [1],
             labels: {
               display: true,
               formatter: oldFormatter,
             },
-            tree: [1],
           },
         ],
       },
@@ -305,7 +336,7 @@ describe('controller', () => {
   it('resolves layout options from the dataset scope and ignores the elements scope', () => {
     const widths = (options) => {
       const chart = acquireChart({
-        data: { datasets: [{ tree: [4, 3, 2, 1] }] },
+        data: { datasets: [{ data: [4, 3, 2, 1] }] },
         options,
         type: 'treemap',
       })
@@ -321,5 +352,57 @@ describe('controller', () => {
     // ...while the dataset scope does, which is what makes the assertion above
     // a statement about scopes rather than about spacing being ignored.
     expect(widths({ datasets: { treemap: { spacing: 20 } } })).not.toEqual(base)
+  })
+
+  it('labels tooltips from the layout node, not from the dataset array', () => {
+    const chart = acquireChart({
+      data: {
+        datasets: [
+          {
+            data: [{ category: 'a', value: 3 }],
+            groups: ['category'],
+            key: 'value',
+            label: 'dataset label',
+          },
+        ],
+      },
+      type: 'treemap',
+    })
+    const controller = chart.getDatasetMeta(0).controller
+
+    expect(controller.getLabelAndValue(0)).toEqual({ label: 'a', value: '3' })
+  })
+
+  it('falls back to the dataset label when a node has no group', () => {
+    const chart = acquireChart({
+      data: { datasets: [{ data: [3], label: 'dataset label' }] },
+      type: 'treemap',
+    })
+    const controller = chart.getDatasetMeta(0).controller
+
+    expect(controller.getLabelAndValue(0)).toEqual({ label: 'dataset label', value: '3' })
+  })
+
+  it('gives scriptable options the layout node as ctx.raw', () => {
+    const seen = []
+    acquireChart({
+      data: {
+        datasets: [
+          {
+            backgroundColor: (ctx) => {
+              if (ctx.raw) {
+                seen.push(ctx.raw.v)
+              }
+              return 'red'
+            },
+            data: [4, 2],
+          },
+        ],
+      },
+      type: 'treemap',
+    })
+
+    expect(seen).toContain(4)
+    expect(seen).toContain(2)
   })
 })

--- a/test/types/data.ts
+++ b/test/types/data.ts
@@ -5,8 +5,7 @@ import '../../dist/index.esm'
 const _data: ChartData<'treemap'> = {
   datasets: [
     {
-      data: [],
-      tree: [15, 6, 6, 5, 4, 3, 2, 2],
+      data: [15, 6, 6, 5, 4, 3, 2, 2],
     },
   ],
 }

--- a/test/types/options.ts
+++ b/test/types/options.ts
@@ -18,7 +18,7 @@ const _chart = new Chart('test', {
     datasets: [
       {
         backgroundColor(ctx) {
-          const item = ctx.dataset.data[ctx.dataIndex]
+          const item = ctx.raw
           if (!item) {
             return 'transparent'
           }
@@ -27,7 +27,7 @@ const _chart = new Chart('test', {
         borderColor: 'rgba(180,180,180, 0.15)',
         borderRadius: 4,
         borderWidth: 2,
-        data: undefined,
+        data: [15, 6, 6, 5, 4, 3, 2, 2],
         label: 'Basic treemap',
         labels: {
           display: true,
@@ -35,8 +35,6 @@ const _chart = new Chart('test', {
             ctx.raw.g ? [ctx.raw.g, ctx.raw.v.toFixed(1)] : ctx.raw.v.toFixed(1),
         },
         spacing: 0.1,
-        tree: [15, 6, 6, 5, 4, 3, 2, 2],
-        treeVersion: 1,
       },
     ],
   },
@@ -52,7 +50,7 @@ const _chart1 = new Chart('test', {
         },
         borderColor: 'black',
         borderWidth: 2,
-        data: undefined,
+        data: [15, 6, 6, 5, 4, 3, 2, 2],
         label: 'Basic treemap',
         labels: {
           align: 'right',
@@ -61,7 +59,6 @@ const _chart1 = new Chart('test', {
           position: 'bottom',
         },
         spacing: 1,
-        tree: [15, 6, 6, 5, 4, 3, 2, 2],
       },
     ],
   },
@@ -94,7 +91,7 @@ const _chart2 = new Chart('test', {
     datasets: [
       {
         backgroundColor(ctx) {
-          const item = ctx.dataset.data[ctx.dataIndex]
+          const item = ctx.raw
           if (!item) {
             return 'black'
           }
@@ -135,11 +132,10 @@ const _chart2 = new Chart('test', {
             weight: 'bold',
           },
         },
-        data: [],
+        data: statsByState,
         groups: ['region', 'division', 'code'],
         key: 'population',
         spacing: 2,
-        tree: statsByState,
       },
     ],
   },
@@ -151,7 +147,7 @@ const _chart3 = new Chart('test', {
     datasets: [
       {
         backgroundColor(ctx) {
-          const item = ctx.dataset.data[ctx.dataIndex]
+          const item = ctx.raw
           if (!item) {
             return 'black'
           }
@@ -170,7 +166,7 @@ const _chart3 = new Chart('test', {
         captions: {
           display: false,
         },
-        data: [],
+        data: statsByState,
         groups: ['region', 'division', 'code'],
         key: 'population',
         labels: {
@@ -188,7 +184,6 @@ const _chart3 = new Chart('test', {
             weight: 'bold',
           },
         },
-        tree: statsByState,
       },
     ],
   },
@@ -202,13 +197,12 @@ const _chart4 = new Chart('test', {
         backgroundColor(_ctx) {
           return '#e6beff'
         },
-        data: [],
+        data: statsByState,
         groups: ['region', 'division', 'code'],
         key: 'population',
         labels: {
           display: false,
         },
-        tree: statsByState,
       },
     ],
   },
@@ -222,7 +216,7 @@ const _chart5 = new Chart('test', {
         backgroundColor(_ctx) {
           return '#e6beff'
         },
-        data: [],
+        data: statsByState,
         groups: ['region', 'division', 'code'],
         key: 'population',
         labels: {
@@ -230,7 +224,6 @@ const _chart5 = new Chart('test', {
           display: false,
           font: [{ size: 24 }, { size: 12 }],
         },
-        tree: statsByState,
       },
     ],
   },


### PR DESCRIPTION
Closes #122. Closes #137. Feature 2 of the v5 plan, the architectural one — landing on the seam that [#462](https://github.com/kurkle/chartjs-chart-treemap/pull/462) and [#463](https://github.com/kurkle/chartjs-chart-treemap/pull/463) prepared.

## What was wrong

The controller read the user's input from `dataset.tree`, ran the layout in `update()`, wrote the resulting rectangles back into `dataset.data`, and then called the private `_dataCheck()` and `_resyncElements()` to make Chart.js create one element per rectangle. Everything awkward about v4's data model follows from that: `treeVersion` had to exist, TypeScript users had to write an empty `data` array for a property the controller immediately overwrote, and React and Vue wrappers saw the dataset mutate on every rebuild.

## What it looks like now

```js
datasets: [{ data: rows, groups: ['region'], key: 'area' }]
```

- **`data` accepts exactly what `tree` accepted** — numbers, objects, or a nested object addressed through `leafKey` — and is never written to.
- **`tree` and `treeVersion` are gone.** A dataset that still has `tree` throws at the first update with a message naming the new option. An empty chart would be a worse way to find out.
- `parse()` produces the layout nodes and `buildOrUpdateElements()` creates one element per node, so **neither reaches for a private Chart.js method any more**.
- `getContext()` puts the node on `ctx.raw` and `ctx.parsed`, exactly as in v4, so existing scriptable callbacks keep working unchanged.
- `getLabelAndValue()` means the default tooltip reads sensibly, and tooltip items carry the node as `item.parsed`.
- `flattenTree()` is exported for TypeScript users who would rather pass an array than a generic.

An in-place edit is picked up by the next `chart.update()` with no version stamp, because parsing runs on every update like every other Chart.js controller. A fingerprint over the parsed nodes keeps that cheap: when the hierarchy is unchanged the previous nodes are kept, so **a `chart.update('none')` per wheel event does not re-run the layout** — the zoom sample's case.

In `headerBoxes` mode a group whose caption does not fit is now hidden rather than dropped, because the number of parsed nodes must not depend on the size of the chart area.

## Verification

- **The 62 pixel fixtures render identically with `data` instead of `tree`.** No PNG was regenerated.
- Checked at runtime rather than assumed, on a grouped chart:

```
node keys: _data,a,g,gs,h,isLeaf,l,s,v,vs,w,x,y   <- exactly the v4 set
_children enumerable: false                        <- internal link stays out of ctx.raw
user rows untouched: true
dataset.data is the same array: true
element count: 2 | parsed: 2
```

- New browser specs cover what the pixels cannot: the user's array is the same object afterwards and unmodified; an in-place edit, an item edit and a `push` are all picked up without a version stamp; `tree` throws with the migration message; `getLabelAndValue` reads the group and falls back to the dataset label; scriptable options receive the node as `ctx.raw`.
- The type tests lost the `data: []` workaround and now read `ctx.raw` where they used to index `dataset.data`.

## Deviation from the plan

The node type keeps the name `TreemapDataPoint` rather than becoming `TreemapNode` with a deprecated alias. It is the type Chart.js parses into, the shape is unchanged, and renaming it would churn every consumer's imports for nothing.

## Migration

| v4 | v5 |
| --- | --- |
| `tree: [...]`, plus `data: []` for TypeScript | `data: [...]` |
| bump `treeVersion` after an in-place edit | just `chart.update()` |
| `dataset.data[i]` is a rectangle | `dataset.data` is your rows; the rectangle is `ctx.raw` / `item.parsed` / `controller.getParsed(i)` |
| datalabels `formatter: (value) => value.v` | `formatter: (_v, ctx) => ctx.chart.getDatasetMeta(ctx.datasetIndex).controller.getParsed(ctx.dataIndex).v` |

A plugin that walks `dataset.data` alongside `getDatasetMeta(i).data` will see different lengths whenever the chart has groups. That is now documented on the usage page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)