### PR TITLE
fix(test): the browser launch flags were never applied

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -22,6 +22,7 @@
       "test/types/**/*.ts",
       "test/utils/**/*.js",
       "tsconfig.test.json",
+      "tsconfig.tooling.json",
       "types/**/*.json",
       "types/**/*.ts",
       "vitest.browser.config.ts",

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "test:integration:node-module": "node test/integration/node-module/test.mjs",
     "test:integration:webpack": "node test/integration/webpack/test.mjs",
     "test:unit": "vitest run --config vitest.config.ts --coverage",
-    "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.test.json && tsc -p tsconfig.json --emitDeclarationOnly && tsc --noEmit -p test/types/",
+    "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.test.json && tsc -p tsconfig.json --emitDeclarationOnly && tsc --noEmit -p test/types/ && tsc --noEmit -p tsconfig.tooling.json",
     "typecheck:docs": "astro check"
   },
   "sideEffects": [

--- a/tsconfig.tooling.json
+++ b/tsconfig.tooling.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "alwaysStrict": true,
+    "module": "ES2022",
+    "moduleResolution": "Bundler",
+    "noEmit": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "target": "ES2022"
+  },
+  "include": ["./vitest.config.ts", "./vitest.browser.config.ts", "./vitest.integration.config.ts"]
+}

--- a/vitest.browser.config.ts
+++ b/vitest.browser.config.ts
@@ -3,6 +3,12 @@ import { defineConfig } from 'vitest/config'
 
 // The same flags karma.conf.cjs used, so the canvas is rasterized by the CPU
 // in both browsers and the pixel fixtures stay comparable.
+//
+// These belong to the provider, not to an instance. Vitest accepts a `launch`
+// or `launchOptions` key on an instance and silently ignores both: verified by
+// pointing `executablePath` at a file that does not exist and watching the run
+// pass anyway. At provider level the same sabotage fails the run, which is how
+// we know these reach Playwright.
 const chromiumArgs = [
   '--disable-accelerated-2d-canvas',
   '--disable-background-timer-throttling',
@@ -20,11 +26,10 @@ export default defineConfig({
     browser: {
       enabled: true,
       headless: true,
-      instances: [
-        { browser: 'chromium', launch: { args: chromiumArgs } },
-        { browser: 'firefox', launch: { firefoxUserPrefs: firefoxPrefs } },
-      ],
-      provider: playwright(),
+      instances: [{ browser: 'chromium' }, { browser: 'firefox' }],
+      provider: playwright({
+        launchOptions: { args: chromiumArgs, firefoxUserPrefs: firefoxPrefs },
+      }),
       screenshotFailures: false,
     },
     // Istanbul, not v8: v8 coverage is collected over the Chrome DevTools


### PR DESCRIPTION
The Vitest migration carried the GPU-disabling flags over from `karma.conf.cjs` onto each browser instance, and [#455](https://github.com/kurkle/chartjs-chart-treemap/pull/455) said so. Vitest accepts `launch` on an instance, **ignores it, and says nothing** — so those flags have not been in effect once since the migration.

## Established by sabotage, not by reading

Pointing `executablePath` at a file that does not exist, and watching what happens:

| where the option was put | result |
| --- | --- |
| `playwright({ launchOptions })` — provider | **exit 1, no tests** → reaches Playwright |
| instance-level `launchOptions` | exit 0, tests ran → ignored |
| instance-level `launch` | exit 0, tests ran → ignored, **and this is what we had** |

The flags move to the provider, where one `launchOptions` serves both browsers: Playwright applies `args` to Chromium and `firefoxUserPrefs` to Firefox and ignores the other.

## They are load-bearing, which is not obvious given they were inert

Since everything passed without them, the fair question is whether five-year-old flags are needed at all in current browsers. Tested by forcing the **opposite** — acceleration explicitly on:

```
--enable-accelerated-2d-canvas --enable-gpu
gfx.canvas.accelerated: true, layers.acceleration.disabled: false

  × advanced/toggle-rtl   × advanced/zoom    × basic/borderWidth
  × basic/update          × basic/update-tree × events/tooltip
  Tests  6 failed | 152 passed (158)      (repeatable, both browsers)
```

So the flags are not tradition: they matter whenever a browser decides to accelerate the canvas. That the suite passed without them means the **current headless defaults already agree with them**, not that they are unnecessary. Making them real is cheap insurance against a browser version or an environment that decides otherwise.

Only the canvas settings are proven that way. The three backgrounding/throttling flags change nothing measurable here — they address a hidden tab, which a headless run does not have. Kept because they cost nothing, but flagged as unproven rather than presented as necessary.

## Why a silently ignored key survived review

**The Vitest configuration files were in no tsconfig at all.** `npm run typecheck` covered `src`, the unit tests and `test/types`, and skipped the three config files entirely. They are now covered through `tsconfig.tooling.json`, and the typecheck catches exactly this class of mistake:

```
vitest.browser.config.ts(29,42): error TS2769: No overload matches this call.
  Object literal may only specify known properties, and 'launch' does not
  exist in type 'BrowserInstanceOption'.
```

## One thing this does not explain

Twice during this work the fixture run reported a partial count with everything green — `135 passed (146)` and `79 passed (158)` — with no failures and no error. A browser that fails to *launch* exits 1, as the table above shows, so that is not the cause. It has never happened in CI and I could not reproduce it across six consecutive runs. Recording it rather than guessing: **a fixture run reporting fewer than 158 is a failure, not a pass**, whatever the exit code says.

## Verification

All 158 browser tests pass with the flags in effect, so no reference image depended on their absence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)