### PR TITLE
test: default pixelmatch's checkerboard option to off

### DIFF
--- a/test/utils/matchers.js
+++ b/test/utils/matchers.js
@@ -50,6 +50,16 @@ export function toEqualImageData(actual, expected, opts = {}) {
 
   const threshold = opts.threshold === undefined ? DEFAULT_THRESHOLD : opts.threshold
   const tolerance = opts.tolerance === undefined ? DEFAULT_TOLERANCE : opts.tolerance
+  // pixelmatch 7.2.0 added a `checkerboard` option and defaulted it to true,
+  // changing how semi-transparent pixels are compared -- in a minor release,
+  // which a `^7.1.0` range picks up on any lockfile refresh. Every reference
+  // PNG here was captured under pixelmatch 5, which blended them against plain
+  // white and offered no alternative. Checkerboard blending is a different
+  // measurement rather than a stricter one: each goes blind where the ink
+  // colour meets the background it is blended against. Default to white, and
+  // let a fixture opt into the checkerboard once its reference image has been
+  // re-validated against it.
+  const checkerboard = opts.checkerboard === true
   const { height, width } = expected
   const actualWidth = ctx.canvas.width
   const actualHeight = ctx.canvas.height
@@ -58,7 +68,10 @@ export function toEqualImageData(actual, expected, opts = {}) {
   const diffData = createImageData(width, height)
   const count =
     actualWidth === width && actualHeight === height
-      ? pixelmatch(actualData.data, expected.data, diffData.data, width, height, { threshold })
+      ? pixelmatch(actualData.data, expected.data, diffData.data, width, height, {
+          checkerboard,
+          threshold,
+        })
       : Math.abs(actualWidth * actualHeight - width * height)
   const ratio = count / (width * height)
   const pass = ratio <= tolerance && !opts.debug


### PR DESCRIPTION
## Summary

pixelmatch 7.2.0 added a `checkerboard` option and defaulted it to
`true`, changing how semi-transparent pixels are blended for
comparison -- in a minor release, which this repo's existing
`pixelmatch: "^7.1.0"` range picks up on any lockfile refresh
(pixelmatch@7.2.0 is already installed here). Versions 5.3.0, 6.0.0,
7.0.0, 7.1.0 and 7.1.1 don't know the option and always blend
semi-transparent pixels against plain white; every reference PNG in
this repo was captured under pixelmatch 5.

Checkerboard blending is a different measurement, not a stricter one:
each mode goes blind wherever the ink colour happens to match the
background it's blended against. Defaulting to white keeps the
fixture suite measuring what its reference images were actually
captured against.

This is the same change already made in chartjs-chart-sankey's
`test/vitest-migration` branch, which the other sibling repos
(chartjs-chart-matrix, chartjs-plugin-gradient,
chartjs-plugin-autocolors) are also picking up as they migrate to
this repo's Vitest setup. `test/utils/matchers.js` is meant to end up
identical across all of them ahead of being split into a shared
package.

## What changed

- `test/utils/matchers.js`: `toEqualImageData` now resolves a
  `checkerboard` option (default `false`) and passes it through to
  `pixelmatch` alongside `threshold`.
- No fixtures, thresholds, or tolerances were touched.

## Test plan

- [x] `npm run test:fixture` (61 fixtures x chromium + firefox = 142
      tests) -- all green, including the 35 fixtures that exercise
      `spriteText`.
- [x] `npm test` (unit + fixture + all three integration suites) --
      all green.
- [x] Tamper test: mutated a block of pixels in
      `test/fixtures/basic/basic.png`, reran the fixture spec, and
      confirmed it failed in both browsers (~1.22% diff, over the
      0.1% tolerance) -- proves the white-blend comparison isn't
      blind to colour changes. Reverted the fixture and reran to
      confirm green again; `git status` shows no fixture changes.
- [x] `npm run lint`, `npm run typecheck`, `npm run build` -- all
      pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)